### PR TITLE
Add Challenge 2: Verify the memory safery of core intrinsics using raw pointers

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -12,5 +12,4 @@
 ---
 
 # Challenges
-- [Coming soon](./todo.md)
 - [Memory safety of core intrinsics](./intrinsics-memory.md)

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -4,6 +4,7 @@
 
 - [General Rules](./general-rules.md)
   - [Challenge Template](./template.md)
+  - [Tool application](./todo.md)
 
 - [Verification Tools](./tools.md)
   - [Kani](./tools/kani.md)

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -13,3 +13,4 @@
 
 # Challenges
 - [Coming soon](./todo.md)
+- [Memory safety of core intrinsics](./intrinsics-memory.md)

--- a/doc/src/general-rules.md
+++ b/doc/src/general-rules.md
@@ -10,7 +10,7 @@ NOTE: This work is not officially affiliated, or endorsed by the Rust project or
 tracking issue where contributors can add comments and ask clarification questions.
 You can find the list of [open challenges here](https://github.com/model-checking/verify-rust-std/labels/Challenge).
 
-**Solutions:** Solutions to a problem should be submitted as a single Pull Request (PR) to this repository. 
+**Solutions:** Solutions to a problem should be submitted as a single Pull Request (PR) to this repository.
 The solution should run as part of the CI.
 See more details about [minimum requirements for each solution](general-rules.md#solution-requirements).
 
@@ -33,13 +33,13 @@ well as to track the status of the challenge.
 
 A proposed solution to a verification problem will only **be reviewed** if all the minimum requirements below are met:
 
-* Each contribution or attempt should be submitted via a pull request to be analyzed by reviewers. 
+* Each contribution or attempt should be submitted via a pull request to be analyzed by reviewers.
 * By submitting the solution, participants confirm that they can use, modify, copy, and redistribute their contribution,
   under the terms of their choice.
 * The contribution must be automated and should be checked and pass as part of the PR checks.
 * All tools used by the solution must be in [the list of accepted tools](tools.md#approved-tools),
   and previously integrated in the repository.
-  If that is not the case, please submit a separate [tool application first](todo.md).
+  If that is not the case, please submit a separate [tool application first](./todo.md).
 * There is no restriction on the number of contributors for a solution.
   Make sure you have the rights to submit your solution and that all contributors are properly mentioned.
 * The solution cannot impact the runtime logic of the standard library unless the change is proposed and incorporated
@@ -56,7 +56,7 @@ The type of obstacles users face may depend on which part of the standard librar
 Everyone is welcome to submit new challenge proposals for review by our committee.
 Follow the following steps to create a new proposal:
 
-1. Create a tracking issue using the Issue template [Challenge Proposal](todo.md) for your challenge.
+1. Create a tracking issue using the Issue template [Challenge Proposal](./todo.md) for your challenge.
 2. In your fork of this repository do the following:
     1. Copy the template file (`book/src/challenge_template.md`) to `book/src/challenges/<ID_NUMBER>-<challenge-name>.md`.
     2. Fill in the details according to the template instructions.
@@ -69,7 +69,7 @@ Follow the following steps to create a new proposal:
 
 Solutions must be automated using one of the tools previously approved and listed [here](tools.md#approved-tools):
 
-* Any new tool that participants want to enable will require an application using the Issue template [Tool application](todo.md).
+* Any new tool that participants want to enable will require an application using the Issue template [Tool application](./todo.md).
 * The tool will be analyzed by an independent committee consisting of members from the Rust open-source developers and AWS
 * A new tool application should clearly specify the differences to existing techniques and provide sufficient background
   of why this is needed.

--- a/doc/src/general-rules.md
+++ b/doc/src/general-rules.md
@@ -39,7 +39,7 @@ A proposed solution to a verification problem will only **be reviewed** if all t
 * The contribution must be automated and should be checked and pass as part of the PR checks.
 * All tools used by the solution must be in [the list of accepted tools](tools.md#approved-tools),
   and previously integrated in the repository.
-  If that is not the case, please submit a separate [tool application first](./todo.md).
+  If that is not the case, please submit a separate [tool application first](todo.md).
 * There is no restriction on the number of contributors for a solution.
   Make sure you have the rights to submit your solution and that all contributors are properly mentioned.
 * The solution cannot impact the runtime logic of the standard library unless the change is proposed and incorporated
@@ -56,7 +56,7 @@ The type of obstacles users face may depend on which part of the standard librar
 Everyone is welcome to submit new challenge proposals for review by our committee.
 Follow the following steps to create a new proposal:
 
-1. Create a tracking issue using the Issue template [Challenge Proposal](./todo.md) for your challenge.
+1. Create a tracking issue using the Issue template [Challenge Proposal](template.md) for your challenge.
 2. In your fork of this repository do the following:
     1. Copy the template file (`book/src/challenge_template.md`) to `book/src/challenges/<ID_NUMBER>-<challenge-name>.md`.
     2. Fill in the details according to the template instructions.
@@ -69,7 +69,7 @@ Follow the following steps to create a new proposal:
 
 Solutions must be automated using one of the tools previously approved and listed [here](tools.md#approved-tools):
 
-* Any new tool that participants want to enable will require an application using the Issue template [Tool application](./todo.md).
+* Any new tool that participants want to enable will require an application using the Issue template [Tool application](todo.md).
 * The tool will be analyzed by an independent committee consisting of members from the Rust open-source developers and AWS
 * A new tool application should clearly specify the differences to existing techniques and provide sufficient background
   of why this is needed.

--- a/doc/src/intrinsics-memory.md
+++ b/doc/src/intrinsics-memory.md
@@ -2,8 +2,8 @@
 
 - **Status:** Open
 - **Tracking Issue:** *Link to issue*
-- **Start date:** *YY/MM/DD*
-- **End date:** *YY/MM/DD*
+- **Start date:** *24/06/12*
+- **End date:** *24/12/10*
 
 -------------------
 
@@ -21,7 +21,7 @@ Annotate Rust core::intrinsics functions that manipulate raw pointers with their
 5. The verification of each intrinsic should ensure all the documented safety conditions are met, and that meeting them is enough to guarantee safe usage.
 
 
-### Functions for verification
+Intrinsic functions to be annotated with safety contracts
 
 |Function	|Location	|
 |---	|---	|
@@ -50,7 +50,7 @@ Annotate Rust core::intrinsics functions that manipulate raw pointers with their
 
 
 
-**At least 10 of the following usages of intrinsics were proven safe:**
+All the following usages of intrinsics were proven safe:
 
 |Function	|Location	|
 |---	|---	|
@@ -59,11 +59,10 @@ Annotate Rust core::intrinsics functions that manipulate raw pointers with their
 |swap | core::mem |
 |align_of_val | core::mem |
 |zeroed | core::mem::maybe_uninit |
-|	|	|
 
 
 
-**At least 5 unsafe functions that expose those intrinsics are also annotated with safety contracts, and those contracts are verified:**
+Annotate and verify all the functions that below that expose intrinsics with safety contracts
 
 |Function	|Location	|
 |---	|---	|
@@ -72,7 +71,6 @@ Annotate Rust core::intrinsics functions that manipulate raw pointers with their
 |swap | std::ptr |
 |align_of_val | std::ptr |
 |zeroed | std::ptr |
-|	|	|
 
 
 
@@ -83,7 +81,7 @@ All proofs must automatically ensure the absence of the following undefined beha
 
 * Invoking undefined behavior via compiler intrinsics.
 * Accessing (loading from or storing to) a place that is dangling or based on a misaligned pointer.
-* Uninitialized memory
+* Reading from uninitialized memory except for padding or unions.
 * Mutating immutable bytes.
 * Producing an invalid value
 

--- a/doc/src/intrinsics-memory.md
+++ b/doc/src/intrinsics-memory.md
@@ -1,6 +1,6 @@
 # Challenge 2: Verify the memory safery of core intrinsics using raw pointers
 
-- **Status:** *One of the following: [Open | Resolved | Expired]* Open
+- **Status:** Open
 - **Tracking Issue:** *Link to issue*
 - **Start date:** *YY/MM/DD*
 - **End date:** *YY/MM/DD*
@@ -10,42 +10,42 @@
 
 ## Goal
 
-Annotate Rust core::intrinsics functions that manipulate raw pointers with their safety contract and verify their usage in the standard library are in fact safe.
+Annotate Rust core::intrinsics functions that manipulate raw pointers with their safety contract. Verify their usage in the standard library is in fact safe.
 
-### Success Criteria*
+### Success Criteria
 
 1. All the following intrinsic functions must be annotated with safety contracts.
 2. Any fallback intrinsic implementation must be verified.
-3. For intrinsics modeled in the tool of choice, explain how its implementation matches the intrinsics definition. This can either be done in the PR description or as an entry to the contest book as part of the “Tools” chapter.
-4. For each function, contestants must state clearly the list of assumptions for each proof, how the proofs can be audit, and the list of (implicit and explicit) properties that are guarantee.
-5. The verification of each intrinsics should ensure all the documented safety conditions are met, and that meeting them is enough to guarantee safe usages.
+3. For intrinsics modeled in the tool of choice, explain how their implementation matches the intrinsics definition. This can either be done in the PR description or as an entry to the contest book as part of the “Tools” chapter.
+4. For each function, contestants must state clearly the list of assumptions for each proof, how the proofs can be audited, and the list of (implicit and explicit) properties that are guaranteed.
+5. The verification of each intrinsic should ensure all the documented safety conditions are met, and that meeting them is enough to guarantee safe usage.
 
 
-#### Functions for verification
+### Functions for verification
 
 |Function	|Location	|
 |---	|---	|
 |typed_swap | core::intrisics |
-vtable_size| core::intrisics |
-vtable_align| core::intrisics |
-copy_nonoverlapping| core::intrisics |
-copy| core::intrisics |
-write_bytes| core::intrisics |
-size_of_val| core::intrisics |
-arith_offset| core::intrisics |
-volatile_copy_nonoverlapping_memory| core::intrisics |
-volatile_copy_memory| core::intrisics |
-volatile_set_memory| core::intrisics |
-volatile_load| core::intrisics |
-volatile_store| core::intrisics |
-unaligned_volatile_load| core::intrisics |
-unaligned_volatile_store| core::intrisics |
-compare_bytes| core::intrisics |
-min_align_of_val| core::intrisics |
-ptr_offset_from| core::intrisics |
-ptr_offset_from_unsigned| core::intrisics |
-read_via_copy| core::intrisics |
-write_via_move| core::intrisics |
+|vtable_size| core::intrisics |
+|vtable_align| core::intrisics |
+|copy_nonoverlapping| core::intrisics |
+|copy| core::intrisics |
+|write_bytes| core::intrisics |
+|size_of_val| core::intrisics |
+|arith_offset| core::intrisics |
+|volatile_copy_nonoverlapping_memory| core::intrisics |
+|volatile_copy_memory| core::intrisics |
+|volatile_set_memory| core::intrisics |
+|volatile_load| core::intrisics |
+|volatile_store| core::intrisics |
+|unaligned_volatile_load| core::intrisics |
+|unaligned_volatile_store| core::intrisics |
+|compare_bytes| core::intrisics |
+|min_align_of_val| core::intrisics |
+|ptr_offset_from| core::intrisics |
+|ptr_offset_from_unsigned| core::intrisics |
+|read_via_copy| core::intrisics |
+|write_via_move| core::intrisics |
 |	|	|
 
 
@@ -55,10 +55,10 @@ write_via_move| core::intrisics |
 |Function	|Location	|
 |---	|---	|
 |copy_from_slice	| core::slice |
-parse_u64_into	| std::fmt |
-swap | core::mem |
-align_of_val | core::mem |
-zeroed | core::mem::maybe_uninit |
+|parse_u64_into	| std::fmt |
+|swap | core::mem |
+|align_of_val | core::mem |
+|zeroed | core::mem::maybe_uninit |
 |	|	|
 
 
@@ -68,10 +68,10 @@ zeroed | core::mem::maybe_uninit |
 |Function	|Location	|
 |---	|---	|
 |copy_from_slice	| std::ptr |
-parse_u64_into	| std::ptr |
-swap | std::ptr |
-align_of_val | std::ptr |
-zeroed | std::ptr |
+|parse_u64_into	| std::ptr |
+|swap | std::ptr |
+|align_of_val | std::ptr |
+|zeroed | std::ptr |
 |	|	|
 
 

--- a/doc/src/intrinsics-memory.md
+++ b/doc/src/intrinsics-memory.md
@@ -12,18 +12,6 @@
 
 Annotate Rust core::intrinsics functions that manipulate raw pointers with their safety contract and verify their usage in the standard library are in fact safe.
 
-## Motivation
-
-*Explain why this is a challenge that should be prioritized. Consider using a motivating example.*
-
-## Description
-
-*Describe the challenge in more details.*
-
-### Assumptions
-
-*Mention any assumption that users may make. Example, "assuming the usage of Stacked Borrows".*
-
 ### Success Criteria*
 
 1. All the following intrinsic functions must be annotated with safety contracts.
@@ -102,5 +90,3 @@ All proofs must automatically ensure the absence of the following undefined beha
 
 Note: All solutions to verification challenges need to satisfy the criteria established in the [challenge book](general-rules.md)
 in addition to the ones listed above.
-
-[^challenge_id]: The number of the challenge sorted by publication date.

--- a/doc/src/intrinsics-memory.md
+++ b/doc/src/intrinsics-memory.md
@@ -46,8 +46,6 @@ Intrinsic functions to be annotated with safety contracts
 |ptr_offset_from_unsigned| core::intrisics |
 |read_via_copy| core::intrisics |
 |write_via_move| core::intrisics |
-|	|	|
-
 
 
 All the following usages of intrinsics were proven safe:

--- a/doc/src/intrinsics-memory.md
+++ b/doc/src/intrinsics-memory.md
@@ -1,7 +1,7 @@
 # Challenge 2: Verify the memory safery of core intrinsics using raw pointers
 
 - **Status:** Open
-- **Tracking Issue:** *Link to issue*
+- **Tracking Issue:** [Link to issue](https://github.com/model-checking/verify-rust-std/issues/16)
 - **Start date:** *24/06/12*
 - **End date:** *24/12/10*
 

--- a/doc/src/intrinsics-memory.md
+++ b/doc/src/intrinsics-memory.md
@@ -23,8 +23,8 @@ Annotate Rust core::intrinsics functions that manipulate raw pointers with their
 
 Intrinsic functions to be annotated with safety contracts
 
-|Function	|Location	|
-|---	|---	|
+| Function | Location |
+|---------|---------|
 |typed_swap | core::intrisics |
 |vtable_size| core::intrisics |
 |vtable_align| core::intrisics |
@@ -50,8 +50,8 @@ Intrinsic functions to be annotated with safety contracts
 
 All the following usages of intrinsics were proven safe:
 
-|Function	|Location	|
-|---	|---	|
+| Function | Location |
+|---------|---------|
 |copy_from_slice	| core::slice |
 |parse_u64_into	| std::fmt |
 |swap | core::mem |
@@ -62,14 +62,13 @@ All the following usages of intrinsics were proven safe:
 
 Annotate and verify all the functions that below that expose intrinsics with safety contracts
 
-|Function	|Location	|
-|---	|---	|
+| Function | Location |
+|---------|---------|
 |copy_from_slice	| std::ptr |
 |parse_u64_into	| std::ptr |
 |swap | std::ptr |
 |align_of_val | std::ptr |
 |zeroed | std::ptr |
-
 
 
 

--- a/doc/src/intrinsics-memory.md
+++ b/doc/src/intrinsics-memory.md
@@ -75,7 +75,7 @@ Annotate and verify all the functions that below that expose intrinsics with saf
 
 ### List of UBs
 
-All proofs must automatically ensure the absence of the following undefined behaviors [[ref]](https://github.com/rust-lang/reference/blob/142b2ed77d33f37a9973772bd95e6144ed9dce43/src/behavior-considered-undefined.md):
+All proofs must automatically ensure the absence of the following undefined behaviors [ref](https://github.com/rust-lang/reference/blob/142b2ed77d33f37a9973772bd95e6144ed9dce43/src/behavior-considered-undefined.md):
 
 * Invoking undefined behavior via compiler intrinsics.
 * Accessing (loading from or storing to) a place that is dangling or based on a misaligned pointer.

--- a/doc/src/intrinsics-memory.md
+++ b/doc/src/intrinsics-memory.md
@@ -1,0 +1,106 @@
+# Challenge 2: Verify the memory safery of core intrinsics using raw pointers
+
+- **Status:** *One of the following: [Open | Resolved | Expired]* Open
+- **Tracking Issue:** *Link to issue*
+- **Start date:** *YY/MM/DD*
+- **End date:** *YY/MM/DD*
+
+-------------------
+
+
+## Goal
+
+Annotate Rust core::intrinsics functions that manipulate raw pointers with their safety contract and verify their usage in the standard library are in fact safe.
+
+## Motivation
+
+*Explain why this is a challenge that should be prioritized. Consider using a motivating example.*
+
+## Description
+
+*Describe the challenge in more details.*
+
+### Assumptions
+
+*Mention any assumption that users may make. Example, "assuming the usage of Stacked Borrows".*
+
+### Success Criteria*
+
+1. All the following intrinsic functions must be annotated with safety contracts.
+2. Any fallback intrinsic implementation must be verified.
+3. For intrinsics modeled in the tool of choice, explain how its implementation matches the intrinsics definition. This can either be done in the PR description or as an entry to the contest book as part of the “Tools” chapter.
+4. For each function, contestants must state clearly the list of assumptions for each proof, how the proofs can be audit, and the list of (implicit and explicit) properties that are guarantee.
+5. The verification of each intrinsics should ensure all the documented safety conditions are met, and that meeting them is enough to guarantee safe usages.
+
+
+#### Functions for verification
+
+|Function	|Location	|
+|---	|---	|
+|typed_swap | core::intrisics |
+vtable_size| core::intrisics |
+vtable_align| core::intrisics |
+copy_nonoverlapping| core::intrisics |
+copy| core::intrisics |
+write_bytes| core::intrisics |
+size_of_val| core::intrisics |
+arith_offset| core::intrisics |
+volatile_copy_nonoverlapping_memory| core::intrisics |
+volatile_copy_memory| core::intrisics |
+volatile_set_memory| core::intrisics |
+volatile_load| core::intrisics |
+volatile_store| core::intrisics |
+unaligned_volatile_load| core::intrisics |
+unaligned_volatile_store| core::intrisics |
+compare_bytes| core::intrisics |
+min_align_of_val| core::intrisics |
+ptr_offset_from| core::intrisics |
+ptr_offset_from_unsigned| core::intrisics |
+read_via_copy| core::intrisics |
+write_via_move| core::intrisics |
+|	|	|
+
+
+
+**At least 10 of the following usages of intrinsics were proven safe:**
+
+|Function	|Location	|
+|---	|---	|
+|copy_from_slice	| core::slice |
+parse_u64_into	| std::fmt |
+swap | core::mem |
+align_of_val | core::mem |
+zeroed | core::mem::maybe_uninit |
+|	|	|
+
+
+
+**At least 5 unsafe functions that expose those intrinsics are also annotated with safety contracts, and those contracts are verified:**
+
+|Function	|Location	|
+|---	|---	|
+|copy_from_slice	| std::ptr |
+parse_u64_into	| std::ptr |
+swap | std::ptr |
+align_of_val | std::ptr |
+zeroed | std::ptr |
+|	|	|
+
+
+
+
+### List of UBs
+
+All proofs must automatically ensure the absence of the following undefined behaviors [[ref]](https://github.com/rust-lang/reference/blob/142b2ed77d33f37a9973772bd95e6144ed9dce43/src/behavior-considered-undefined.md):
+
+* Invoking undefined behavior via compiler intrinsics.
+* Accessing (loading from or storing to) a place that is dangling or based on a misaligned pointer.
+* Uninitialized memory
+* Mutating immutable bytes.
+* Producing an invalid value
+
+
+Note: All solutions to verification challenges need to satisfy the criteria established in the [challenge book](general-rules.md)
+in addition to the ones listed above.
+
+[^challenge_id]: The number of the challenge sorted by publication date.

--- a/doc/src/template.md
+++ b/doc/src/template.md
@@ -25,29 +25,21 @@
 
 *Mention any assumption that users may make. Example, "assuming the usage of Stacked Borrows".*
 
-### Success Criteria*
+### Success Criteria
 
 *Here are some examples of possible criteria:*
 
 All the following unsafe functions must be annotated with safety contracts and the contracts have been verified:
 
-|Function	|Location	|
-|---	|---	|
-|	|	|
-|	|	|
-|	|	|
-|	|	|
-|	|	|
+| Function | Location |
+|---------|---------|
+|  abc   |  def    |
 
 At least N of the following usages were proven safe:
 
-|Function	|Location	|
-|---	|---	|
-|	|	|
-|	|	|
-|	|	|
-|	|	|
-|	|	|
+| Function | Location |
+|---------|---------|
+|  xyz   |  123   |
 
 All proofs must automatically ensure the absence of the following undefined behaviors [ref](https://github.com/rust-lang/reference/blob/142b2ed77d33f37a9973772bd95e6144ed9dce43/src/behavior-considered-undefined.md):
 

--- a/doc/src/template.md
+++ b/doc/src/template.md
@@ -49,7 +49,7 @@ At least N of the following usages were proven safe:
 |	|	|
 |	|	|
 
-All proofs must automatically ensure the absence of the following undefined behaviors [[ref]](https://github.com/rust-lang/reference/blob/142b2ed77d33f37a9973772bd95e6144ed9dce43/src/behavior-considered-undefined.md):
+All proofs must automatically ensure the absence of the following undefined behaviors [ref](https://github.com/rust-lang/reference/blob/142b2ed77d33f37a9973772bd95e6144ed9dce43/src/behavior-considered-undefined.md):
 
 *List of UBs*
 


### PR DESCRIPTION
Adds the challenge to `Verify the memory safery of core intrinsics using raw pointers`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
