### PR TITLE
Run CI checks on all PRs against to main

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -2,16 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 # This workflow is responsible for building and releasing the book.
-# It should only run when there has been a change to the book files
-# or via manual trigger.
 
 name: Build Book
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'doc/**'
-      - '.github/workflows/book.yml'
+    branches: [ main ]
   push:
     paths:
       - 'doc/**'

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -7,9 +7,7 @@ name: Kani
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'library/**'
-      - '.github/workflows/kani.yml'
+    branches: [ main ]
   push:
     paths:
       - 'library/**'

--- a/.github/workflows/rustc.yml
+++ b/.github/workflows/rustc.yml
@@ -8,10 +8,7 @@ name: Rust Tests
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'library/**'
-      - 'rust-toolchain.toml'
-      - '.github/workflows/rustc.yml'
+    branches: [ main ]
   push:
     paths:
       - 'library/**'


### PR DESCRIPTION
With path-based filters for CI jobs we cannot consistently use branch protection as jobs marked "required" wouldn't necessarily run on a given PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
