### PR TITLE
Add tracking issue for challenges template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -1,0 +1,12 @@
+---
+name: Tracking issue for challenge
+about: Create a new tracking issue for a challenge
+title: "[Tracking Challenge] "
+labels: Challenge
+---
+
+> **IMPORTANT:** Before submitting this issue, please add this challenge to the runbook and include the link below.
+
+## Runbook Link
+
+[Paste the link to the runbook page for this challenge here]


### PR DESCRIPTION
Creates an issue template for new issues that are for tracking challenges. 
Right now, anyone can add a tracking issue for a challenge without the link to the challenge in the runbook.
This template will help remind them of the order of creation which would be to first, create the challenge in the runbook, then create the tracking issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
