### PR TITLE
Add new templates for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,10 @@
+---
+name: Generic Issue
+about: For any type of issue or improvement
+---
+
+## Description
+[Describe the issue or task here]
+
+## Additional Information
+[Add any other relevant details]

--- a/.github/ISSUE_TEMPLATE/maintainence.md
+++ b/.github/ISSUE_TEMPLATE/maintainence.md
@@ -1,0 +1,14 @@
+---
+name: Maintenance Task
+about: For repository upkeep and improvements
+title: '[MAINTENANCE] '
+labels: Maintenance
+---
+
+[Briefly describe the maintenance task]
+
+## Proposed Changes
+[Outline the proposed changes or improvements]
+
+## Rationale
+[Explain why this maintenance is necessary]


### PR DESCRIPTION
With the new template for tracking issues, there is no path for users to create issues for maintainence of generic issues. These templates allow users to create issues that are maintainence related or generic in nature.

Call-out:
1. Need templates in the future for tool applications and challenge proposals?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
