### PR TITLE
Add committee application guideline and committee TOML file

### DIFF
--- a/.github/pull_requests.toml
+++ b/.github/pull_requests.toml
@@ -1,3 +1,13 @@
 [committee]
 members = [
+    "celinval",
+    "rahulku",
+    "pnkfelix",
+    "adpaco-aws",
+    "feliperodri",
+    "zhassan-aws",
+    "remi-delmas-3000",
+    "qinheping",
+    "tautschnig"
+    "jaisnan"
 ]

--- a/.github/pull_requests.toml
+++ b/.github/pull_requests.toml
@@ -8,6 +8,6 @@ members = [
     "zhassan-aws",
     "remi-delmas-3000",
     "qinheping",
-    "tautschnig"
+    "tautschnig",
     "jaisnan"
 ]

--- a/.github/pull_requests.toml
+++ b/.github/pull_requests.toml
@@ -1,0 +1,3 @@
+[committee]
+members = [
+]

--- a/doc/src/general-rules.md
+++ b/doc/src/general-rules.md
@@ -84,7 +84,7 @@ Solutions must be automated using one of the tools previously approved and liste
 
 ## Committee Applications
 
-You can apply to be part of the committee by submitting a pull request that adds your github login name to the pull_request.toml file.
+You can apply to be part of the committee by submitting a pull request that adds your GitHub login name to the `pull_request.toml` file.
 
 For example, if your user login is @rahulku, add the login without @ to the committee member's list,
 ```

--- a/doc/src/general-rules.md
+++ b/doc/src/general-rules.md
@@ -81,3 +81,15 @@ Solutions must be automated using one of the tools previously approved and liste
   I.e., the action may no longer pass after an update.
   This will not impact the approval status of the tool, however,
   new solutions that want to employ the tool may need to ensure the action is passing first.
+
+## Committee Applications
+
+You can apply to be part of the committee by submitting a pull request that adds your github login name to the pull_request.toml file.
+
+For example, add @rahulku without @ to the committee member's list,
+```
+[committee]
+members = [
++   "rahulku"
+]
+```

--- a/doc/src/general-rules.md
+++ b/doc/src/general-rules.md
@@ -86,7 +86,7 @@ Solutions must be automated using one of the tools previously approved and liste
 
 You can apply to be part of the committee by submitting a pull request that adds your github login name to the pull_request.toml file.
 
-For example, add @rahulku without @ to the committee member's list,
+For example, if your user login is @rahulku, add the login without @ to the committee member's list,
 ```
 [committee]
 members = [


### PR DESCRIPTION
This PR adds 

1. An empty committee `toml` file as a cache that will be used by the CI workflow to check if the approvers belong to the committee.
2. Some simple guidelines for users to apply to become a part of the committee.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
