### PR TITLE
Verifying Unstable Sort for Slices

### DIFF
--- a/library/core/src/slice/sort/shared/smallsort.rs
+++ b/library/core/src/slice/sort/shared/smallsort.rs
@@ -577,6 +577,9 @@ unsafe fn insert_tail<T, F: FnMut(&T, &T) -> bool>(begin: *mut T, tail: *mut T, 
 }
 
 /// Sort `v` assuming `v[..offset]` is already sorted.
+#[kani::requires(offset !=0)]
+#[kani::requires(offset <= v.len())]
+#[kani::modifies(v)]
 pub fn insertion_sort_shift_left<T, F: FnMut(&T, &T) -> bool>(
     v: &mut [T],
     offset: usize,
@@ -861,19 +864,19 @@ pub(crate) const fn has_efficient_in_place_swap<T>() -> bool {
 mod verify {
     use super::*;
 
-    #[kani::requires(offset !=0)]
-    #[kani::requires(offset <= v.len())]
-    #[kani::requires(v[0..offset].is_sorted_by(is_less.clone()))]
-    #[kani::modifies(v)]
-    #[kani::ensures(|_| v.is_sorted_by(is_less.clone()))]
-    pub fn insertion_sort_shift_left_clone<T, F: FnMut(&T, &T) -> bool + Clone>(v: &mut [T], offset: usize, is_less: &mut F) {
-        insertion_sort_shift_left(v,offset,is_less)
-    }
+    //#[kani::requires(offset !=0)]
+    //#[kani::requires(offset <= v.len())]
+    //#[kani::requires(v[0..offset].is_sorted_by(is_less.clone()))]
+    //#[kani::modifies(v)]
+    //#[kani::ensures(|_| v.is_sorted_by(is_less.clone()))]
+    //pub fn insertion_sort_shift_left_clone<T, F: FnMut(&T, &T) -> bool + Clone>(v: &mut [T], offset: usize, is_less: &mut F) {
+    //    insertion_sort_shift_left(v,offset,is_less)
+    //}
 
-    #[kani::proof_for_contract(insertion_sort_shift_left_clone)]
+    #[kani::proof_for_contract(insertion_sort_shift_left)]
     pub fn insertion_sort_shift_left_harness(){
-        let mut arr: [u32; 2] = crate::array::from_fn(|_| kani::any::<u32>());
+        let mut arr: [u32; 10] = crate::array::from_fn(|_| kani::any::<u32>());
         let x : &mut [u32] = arr.as_mut_slice();
-        insertion_sort_shift_left_clone(x,1,&mut |a,b| a <= b)
+        insertion_sort_shift_left(x,1,&mut |a,b| a <= b)
     }
 }

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -1,5 +1,7 @@
 //! This module contains the entry points for `slice::sort_unstable`.
 
+use crate::kani;
+
 use crate::intrinsics;
 use crate::mem::SizedTypeProperties;
 
@@ -73,4 +75,24 @@ where
     // The binary OR by one is used to eliminate the zero-check in the logarithm.
     let limit = 2 * (len | 1).ilog2();
     crate::slice::sort::unstable::quicksort::quicksort(v, None, limit, is_less);
+}
+
+
+#[cfg(kani)]
+#[unstable(feature="kani", issue="none")]
+mod verify {
+    use super::*;
+
+    #[kani::modifies(v)]
+    #[kani::ensures(|_| v.is_sorted_by(|a,b| a < b))]
+    pub fn sort_u32(v: &mut [u32]) {
+        sort(v,&mut |a,b| a < b)
+    }
+
+    #[kani::proof_for_contract(sort_u32)]
+    pub fn sort_harness(){
+        let mut arr: [u32; 2] = crate::array::from_fn(|_| kani::any::<u32>());
+        let x : &mut [u32] = arr.as_mut_slice();
+        sort_u32(x)
+    }
 }

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -89,7 +89,7 @@ mod verify {
         sort(v,is_less)
     }
 
-    #[kani::proof_for_contract(sort)]
+    #[kani::proof_for_contract(sort_clone)]
     pub fn sort_harness(){
         let mut arr: [u32; 20] = crate::array::from_fn(|_| kani::any::<u32>());
         let x : &mut [u32] = arr.as_mut_slice();

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -89,9 +89,9 @@ mod verify {
         sort(v,is_less)
     }
 
-    #[kani::proof_for_contract(sort_u32)]
+    #[kani::proof_for_contract(sort)]
     pub fn sort_harness(){
-        let mut arr: [u32; 1] = crate::array::from_fn(|_| kani::any::<u32>());
+        let mut arr: [u32; 20] = crate::array::from_fn(|_| kani::any::<u32>());
         let x : &mut [u32] = arr.as_mut_slice();
         sort_clone(x,&mut |a,b| a < b)
     }

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -91,8 +91,8 @@ mod verify {
 
     #[kani::proof_for_contract(sort_clone)]
     pub fn sort_harness(){
-        let mut arr: [u32; 1] = crate::array::from_fn(|_| kani::any::<u32>());
+        let mut arr: [u32; 2] = crate::array::from_fn(|_| kani::any::<u32>());
         let x : &mut [u32] = arr.as_mut_slice();
-        sort_clone(x,&mut |a,b| a < b)
+        sort_clone(x,&mut |a,b| a <= b)
     }
 }

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -91,7 +91,7 @@ mod verify {
 
     #[kani::proof_for_contract(sort_clone)]
     pub fn sort_harness(){
-        let mut arr: [u32; 20] = crate::array::from_fn(|_| kani::any::<u32>());
+        let mut arr: [u32; 1] = crate::array::from_fn(|_| kani::any::<u32>());
         let x : &mut [u32] = arr.as_mut_slice();
         sort_clone(x,&mut |a,b| a < b)
     }

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -84,15 +84,15 @@ mod verify {
     use super::*;
 
     #[kani::modifies(v)]
-    #[kani::ensures(|_| v.is_sorted_by(|a,b| a < b))]
-    pub fn sort_u32(v: &mut [u32]) {
-        sort(v,&mut |a,b| a < b)
+    #[kani::ensures(|_| v.is_sorted_by(is_less.clone()))]
+    pub fn sort_u32<T, F: FnMut(&T, &T) -> bool + Clone>(v: &mut [T], is_less: &mut F) {
+        sort(v,is_less)
     }
 
     #[kani::proof_for_contract(sort_u32)]
     pub fn sort_harness(){
-        let mut arr: [u32; 2] = crate::array::from_fn(|_| kani::any::<u32>());
+        let mut arr: [u32; 1] = crate::array::from_fn(|_| kani::any::<u32>());
         let x : &mut [u32] = arr.as_mut_slice();
-        sort_u32(x)
+        sort_u32(x,&mut |a,b| a < b)
     }
 }

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod quicksort;
 /// Upholds all safety properties outlined here:
 /// <https://github.com/Voultapher/sort-research-rs/blob/main/writeup/sort_safety/text.md>
 #[inline(always)]
+#[kani::modifies(v)]
 pub fn sort<T, F: FnMut(&T, &T) -> bool>(v: &mut [T], is_less: &mut F) {
     // Arrays of zero-sized types are always all-equal, and thus sorted.
     if T::IS_ZST {
@@ -83,16 +84,16 @@ where
 mod verify {
     use super::*;
 
-    #[kani::modifies(v)]
-    #[kani::ensures(|_| v.is_sorted_by(is_less.clone()))]
-    pub fn sort_clone<T, F: FnMut(&T, &T) -> bool + Clone>(v: &mut [T], is_less: &mut F) {
-        sort(v,is_less)
-    }
+    //#[kani::modifies(v)]
+    //#[kani::ensures(|_| v.is_sorted_by(is_less.clone()))]
+    //pub fn sort_clone<T, F: FnMut(&T, &T) -> bool + Clone>(v: &mut [T], is_less: &mut F) {
+    //    sort(v,is_less)
+    //}
 
-    #[kani::proof_for_contract(sort_clone)]
+    #[kani::proof_for_contract(sort)]
     pub fn sort_harness(){
-        let mut arr: [u32; 2] = crate::array::from_fn(|_| kani::any::<u32>());
+        let mut arr: [u32; 10] = crate::array::from_fn(|_| kani::any::<u32>());
         let x : &mut [u32] = arr.as_mut_slice();
-        sort_clone(x,&mut |a,b| a <= b)
+        sort(x,&mut |a,b| a <= b)
     }
 }

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -85,7 +85,7 @@ mod verify {
 
     #[kani::modifies(v)]
     #[kani::ensures(|_| v.is_sorted_by(is_less.clone()))]
-    pub fn sort_u32<T, F: FnMut(&T, &T) -> bool + Clone>(v: &mut [T], is_less: &mut F) {
+    pub fn sort_clone<T, F: FnMut(&T, &T) -> bool + Clone>(v: &mut [T], is_less: &mut F) {
         sort(v,is_less)
     }
 
@@ -93,6 +93,6 @@ mod verify {
     pub fn sort_harness(){
         let mut arr: [u32; 1] = crate::array::from_fn(|_| kani::any::<u32>());
         let x : &mut [u32] = arr.as_mut_slice();
-        sort_u32(x,&mut |a,b| a < b)
+        sort_clone(x,&mut |a,b| a < b)
     }
 }

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -52,6 +52,7 @@ pub fn sort<T, F: FnMut(&T, &T) -> bool>(v: &mut [T], is_less: &mut F) {
 /// Deliberately don't inline the main sorting routine entrypoint to ensure the
 /// inlined insertion sort i-cache footprint remains minimal.
 #[inline(never)]
+#[kani::modifies(v)]
 fn ipnsort<T, F>(v: &mut [T], is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,
@@ -84,13 +85,16 @@ where
 mod verify {
     use super::*;
 
-    //#[kani::modifies(v)]
-    //#[kani::ensures(|_| v.is_sorted_by(is_less.clone()))]
-    //pub fn sort_clone<T, F: FnMut(&T, &T) -> bool + Clone>(v: &mut [T], is_less: &mut F) {
-    //    sort(v,is_less)
-    //}
-
+    #[kani::proof_for_contract(ipnsort)]
+    pub fn ipnsort_harness(){
+        let mut arr: [u32; 10] = crate::array::from_fn(|_| kani::any::<u32>());
+        let x : &mut [u32] = arr.as_mut_slice();
+        sort(x,&mut |a,b| a <= b)
+    }
+ 
     #[kani::proof_for_contract(sort)]
+    #[kani::stub_verified(ipnsort)]
+    #[kani::stub_verified(insertion_sort_shift_left)]
     pub fn sort_harness(){
         let mut arr: [u32; 10] = crate::array::from_fn(|_| kani::any::<u32>());
         let x : &mut [u32] = arr.as_mut_slice();


### PR DESCRIPTION
Currently only verifies for slices of length 1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
