### PR TITLE
remove deprecated ptr-to-ref-cast-checks

### DIFF
--- a/scripts/check_kani.sh
+++ b/scripts/check_kani.sh
@@ -44,7 +44,7 @@ cargo build-dev --release
 echo "Running tests..."
 echo
 cd "$VERIFY_RUST_STD_DIR"
-$KANI_DIR/scripts/kani verify-std -Z unstable-options $VERIFY_RUST_STD_DIR/library --target-dir "$RUNNER_TEMP" -Z function-contracts -Z mem-predicates -Z ptr-to-ref-cast-checks
+$KANI_DIR/scripts/kani verify-std -Z unstable-options $VERIFY_RUST_STD_DIR/library --target-dir "$RUNNER_TEMP" -Z function-contracts -Z mem-predicates
 
 echo "Tests completed."
 echo


### PR DESCRIPTION
Remove deprecated option from script. I am merging this into the `sync` branch so we can first check that this works as expected in CI for #49, and then we can merge those changes (and this one) into main.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.