### PR TITLE
Clone submodules when updating subtree

### DIFF
--- a/scripts/pull_from_upstream.sh
+++ b/scripts/pull_from_upstream.sh
@@ -22,4 +22,10 @@ git fetch origin
 git checkout -b ${SYNC_BRANCH} origin/main
 git subtree merge --prefix=library subtree/library --squash
 
+# 4. Pull library's submodules
+# The subtree command does not recursively pull submodules, so we do this manually.
+cd library
+git clone https://github.com/rust-lang/backtrace-rs.git
+git clone https://github.com/rust-lang/stdarch.git
+
 # TODO: Update origin/subtree/library as well after the process by pushing to it


### PR DESCRIPTION
`pull_from_upstream.sh` runs `git subtree` to update our copy of `library`, but this command does not pull submodules. 
This PR updates the script to clone `library`'s two submodules (`backtrace` and `stdarch`) automatically.

Without this fix, `check_kani.sh` fails with this error:

```
++ echo 'Running tests...'
Running tests...
++ echo

++ cd /var/folders/2r/g_zkltvs27d511hds3r2_rsw0000gq/T/tmp.Dlu57hiAU0
++ /var/folders/2r/g_zkltvs27d511hds3r2_rsw0000gq/T/tmp.efDFDxOWPB/scripts/kani verify-std -Z unstable-options /var/folders/2r/g_zkltvs27d511hds3r2_rsw0000gq/T/tmp.Dlu57hiAU0/library --target-dir /var/folders/2r/g_zkltvs27d511hds3r2_rsw0000gq/T/tmp.fWNS0lC7vq -Z function-contracts -Z mem-predicates
Kani Rust Verifier 0.54.0 (standalone)
    Creating library package
note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
error: failed to load manifest for workspace member `/private/var/folders/2r/g_zkltvs27d511hds3r2_rsw0000gq/T/tmp.Dlu57hiAU0/library/std`
referenced by workspace at `/private/var/folders/2r/g_zkltvs27d511hds3r2_rsw0000gq/T/tmp.Dlu57hiAU0/Cargo.toml`

Caused by:
  failed to load manifest for dependency `std_detect`

Caused by:
  failed to read `/private/var/folders/2r/g_zkltvs27d511hds3r2_rsw0000gq/T/tmp.Dlu57hiAU0/library/stdarch/crates/std_detect/Cargo.toml`

Caused by:
  No such file or directory (os error 2)
error: Failed to execute cargo (exit status: 101). Found 0 compilation errors.
```

This PR should be merged after #50.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
