### PR TITLE
Remove all section numbers to prevent confusing labelling

### DIFF
--- a/doc/book.toml
+++ b/doc/book.toml
@@ -12,6 +12,7 @@ build-dir = "../book"
 site-url = "/verify-rust-std/"
 git-repository-url = "https://github.com/model-checking/verify-rust-std"
 edit-url-template = "https://github.com/model-checking/verify-rust-std/edit/main/doc/{path}"
+no-section-label = true
 
 [output.html.playground]
 runnable = false


### PR DESCRIPTION
Remove all section numbers to prevent confusing labelling.

This is what the book looks like after this change

![Screenshot 2024-08-28 at 4 50 59 PM](https://github.com/user-attachments/assets/e812f01c-da3d-493c-8b99-424355340f37)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
