### PR TITLE
Prevent skipping due to "if" statement

### DIFF
--- a/.github/workflows/pr_approval.yml
+++ b/.github/workflows/pr_approval.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   check-approvals:
-    if: github.event.review.state == 'APPROVED' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Prevent pr approval from getting skipped when there is a non-approval review submitted on the PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
