### PR TITLE
Add documentation to run Kani on single harnesses

### DIFF
--- a/doc/src/tools/kani.md
+++ b/doc/src/tools/kani.md
@@ -86,9 +86,9 @@ pub mod verify {
 
 ### Step 2
 
-Run the following command in your local terminal (replace /path/ with your local paths):
+Run the following command in your local terminal (replace /path/to/ with your local paths):
 
-`kani verify-std -Z unstable-options "path/to/library" --target-dir "/path/to/target" -Z function-contracts -Z stubbing -Z mem-predicates`.
+`kani verify-std -Z unstable-options "path/to/library" --target-dir "/path/to/target" -Z function-contracts -Z mem-predicates`.
 
 The command `kani verify-std` is a sub-command of the `kani`. This specific sub-command is used to verify the Rust Standard Library with the following arguments.
 

--- a/doc/src/tools/kani.md
+++ b/doc/src/tools/kani.md
@@ -55,12 +55,12 @@ To aid the Rust Standard Library verification effort, Kani provides a sub-comman
 
 Modify your local copy of the Rust Standard Library by writing proofs for the functions/methods that you want to verify.
 
-For example, insert this short blob into your copy of the library. This blob imports the building-block APIs such as
+For example, insert this short blob into a rust file named `example.rs` inside your copy of the library folder. This blob imports the building-block APIs such as
 `assert`, `assume`, `proof` and [function-contracts](https://github.com/model-checking/kani/blob/main/rfc/src/rfcs/0009-function-contracts.md) such as `proof_for_contract` and `fake_function`.
 
 ``` rust
 #[cfg(kani)]
-kani_core::kani_lib!(core);
+use crate::kani;
 
 #[cfg(kani)]
 #[unstable(feature = "kani", issue = "none")]
@@ -88,14 +88,14 @@ pub mod verify {
 
 Run the following command in your local terminal:
 
-`kani verify-std -Z unstable-options "path/to/library" --target-dir "/path/to/target" -Z function-contracts -Z stubbing`.
+`kani verify-std -Z unstable-options "path/to/library" --target-dir "/path/to/target" -Z function-contracts -Z stubbing -Z mem-predicates`.
 
 The command `kani verify-std` is a sub-command of the `kani`. This specific sub-command is used to verify the Rust Standard Library with the following arguments.
 
 - `"path/to/library"`: This argument specifies the path to the modified Rust Standard Library that was prepared earlier in the script.
 - `--target-dir "path/to/target"`: This optional argument sets the target directory where Kani will store its output and intermediate files.
 
-Apart from these, you can use your regular `kani-args` such as `-Z function-contracts` and `-Z stubbing` depending on your verification needs.
+Apart from these, you can use your regular `kani-args` such as `-Z function-contracts`, `-Z stubbing` and `-Z mem-predicates` depending on your verification needs. If you run into kani error that says `Use of unstable feature`, add the corresponding feature with `-Z` to the command.
 For more details on Kani's features, refer to [the features section in the Kani Book](https://model-checking.github.io/kani/reference/attributes.html)
 
 ### Step 3
@@ -111,6 +111,9 @@ Verification Time: 0.017101772s
 
 Complete - 2 successfully verified harnesses, 0 failures, 2 total.
 ```
+
+### Step 4
+Now you can write proof harnesses to verify specific functions in the library. The current convention is to keep proofs in the same module file of the verification target. To run kani for individual proof, use `--harness [harness_function_name]`. Note that Kani will batch run all proofs in the library folder if you do not supply the `--harness` flag. If kani returns the error `no harnesses matched the harness filter`, you can give the fullname of the harness. For example, to run the proof harness named `check_new` in `library/core/src/ptr/unique.rs`, use `--harness ptr::unique::verify::check_new`. To run all proofs in `unique.rs`, use `--harness ptr::unique::verify`. To find the fullname of a harness, check the kani output and find the line starting with `Checking harness [harness fullname]`.
 
 ## More details
 

--- a/doc/src/tools/kani.md
+++ b/doc/src/tools/kani.md
@@ -146,7 +146,7 @@ Complete - 1 successfully verified harnesses, 0 failures, 1 total.
 
 Now you can write proof harnesses to verify specific functions in the library. 
 The current convention is to keep proofs in the same module file of the verification target. 
-To run kani for individual proof, use `--harness [harness_function_name]`. 
+To run Kani for an individual proof, use `--harness [harness_function_name]`. 
 Note that Kani will batch run all proofs in the library folder if you do not supply the `--harness` flag. 
 If kani returns the error `no harnesses matched the harness filter`, you can give the fullname of the harness. 
 For example, to run the proof harness named `check_new` in `library/core/src/ptr/unique.rs`, use 

--- a/doc/src/tools/kani.md
+++ b/doc/src/tools/kani.md
@@ -60,7 +60,7 @@ For example, insert this short blob into a rust file named `example.rs` inside y
 
 ``` rust
 #[cfg(kani)]
-use crate::kani;
+kani_core::kani_lib!(core);
 
 #[cfg(kani)]
 #[unstable(feature = "kani", issue = "none")]

--- a/doc/src/tools/kani.md
+++ b/doc/src/tools/kani.md
@@ -148,7 +148,7 @@ Now you can write proof harnesses to verify specific functions in the library.
 The current convention is to keep proofs in the same module file of the verification target. 
 To run Kani for an individual proof, use `--harness [harness_function_name]`. 
 Note that Kani will batch run all proofs in the library folder if you do not supply the `--harness` flag. 
-If kani returns the error `no harnesses matched the harness filter`, you can give the fullname of the harness. 
+If Kani returns the error `no harnesses matched the harness filter`, you can give the full name of the harness. 
 For example, to run the proof harness named `check_new` in `library/core/src/ptr/unique.rs`, use 
 `--harness ptr::unique::verify::check_new`. To run all proofs in `unique.rs`, use `--harness ptr::unique::verify`. 
 To find the fullname of a harness, check the kani output and find the line starting with `Checking harness [harness fullname]`.

--- a/doc/src/tools/kani.md
+++ b/doc/src/tools/kani.md
@@ -98,7 +98,7 @@ The command `kani verify-std` is a sub-command of the `kani`. This specific sub-
 - `"path/to/library"`: This argument specifies the path to the modified Rust Standard Library that was prepared earlier in the script. For example, `./library` or `/home/ubuntu/verify-rust-std/library`
 - `--target-dir "path/to/target"`: This optional argument sets the target directory where Kani will store its output and intermediate files. For example, `/tmp` or `/tmp/verify-std`
 
-Apart from these, you can use your regular `kani-args` such as `-Z function-contracts`, `-Z stubbing` and `-Z mem-predicates` depending on your verification needs. If you run into kani error that says `Use of unstable feature`, add the corresponding feature with `-Z` to the command.
+Apart from these, you can use your regular `kani-args` such as `-Z function-contracts`, `-Z stubbing` and `-Z mem-predicates` depending on your verification needs. If you run into a Kani error that says `Use of unstable feature`, add the corresponding feature with `-Z` to the command line.
 For more details on Kani's features, refer to [the features section in the Kani Book](https://model-checking.github.io/kani/reference/attributes.html)
 
 ### Step 3 - Check verification result

--- a/doc/src/tools/kani.md
+++ b/doc/src/tools/kani.md
@@ -86,7 +86,7 @@ pub mod verify {
 
 ### Step 2
 
-Run the following command in your local terminal:
+Run the following command in your local terminal (replace /path/ with your local paths):
 
 `kani verify-std -Z unstable-options "path/to/library" --target-dir "/path/to/target" -Z function-contracts -Z stubbing -Z mem-predicates`.
 

--- a/doc/src/tools/kani.md
+++ b/doc/src/tools/kani.md
@@ -151,7 +151,7 @@ Note that Kani will batch run all proofs in the library folder if you do not sup
 If Kani returns the error `no harnesses matched the harness filter`, you can give the full name of the harness. 
 For example, to run the proof harness named `check_new` in `library/core/src/ptr/unique.rs`, use 
 `--harness ptr::unique::verify::check_new`. To run all proofs in `unique.rs`, use `--harness ptr::unique::verify`. 
-To find the fullname of a harness, check the kani output and find the line starting with `Checking harness [harness fullname]`.
+To find the full name of a harness, check the Kani output and find the line starting with `Checking harness [harness full name]`.
 
 ## More details
 


### PR DESCRIPTION
This PR adds to the documentation in the Verification Tools->Kani section of the [challenge book](https://model-checking.github.io/verify-rust-std/tools/kani.html).

### Changes
- Step 1: add clarify on where to put the example code.
- Step 2: add `-Z mem-predicate` to avoid unstable feature errors.
- Step 4: new step to help kani user run specific proofs and identify harness fullnames.

### :exclamation: Issue
I tried to follow step 1 & 2 but kani could not find the harnesses in the example code. At this point there are many proofs in the library so I couldn't find the fullname of the harness in the example code by just running all proofs. I tried to move `example.rs` into `library/core/src/ptr/` and use `--harness ptr::verify::example` or `--harness dummy_proof` but both got `error: no harnesses matched the harness filter`.  Please let me know if you are successful or running into the same issue. 

