### PR TITLE
Contracts & Harnesses for `wrapping_shl`

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2160,10 +2160,6 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline(always)]
         #[rustc_allow_const_fn_unstable(unchecked_shifts)]
-        // Precondition: The right hand side of the shift (rhs) is less than
-        // the number of bits in the type. This prevents undefined behavior.
-        // TODO: Is requires needed? It's already specified in `unchecked_shl`
-        #[requires(rhs < Self::BITS)]
         #[ensures(|result| *result == self << (rhs & (Self::BITS - 1)))]
         pub const fn wrapping_shl(self, rhs: u32) -> Self {
             // SAFETY: the masking by the bitsize of the type ensures that we do not shift

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2160,6 +2160,11 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline(always)]
         #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        // Precondition: The right hand side of the shift (rhs) is less than
+        // the number of bits in the type. This prevents undefined behavior.
+        // TODO: Is requires needed? It's already specified in `unchecked_shl`
+        #[requires(rhs < Self::BITS)]
+        #[ensures(|result| *result == self << (rhs & (Self::BITS - 1)))]
         pub const fn wrapping_shl(self, rhs: u32) -> Self {
             // SAFETY: the masking by the bitsize of the type ensures that we do not shift
             // out of bounds

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1869,7 +1869,6 @@ mod verify {
     // i{8,16,32,64,128,size} and u{8,16,32,64,128,size} -- 12 types in total
     //
     // Target contracts:
-    // #[requires(rhs < Self::BITS)]
     // #[ensures(|result| *result == self << (rhs & (Self::BITS - 1)))]
     //
     // Target function:

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1645,7 +1645,7 @@ mod verify {
         }
     }
 
-    // Verify `wrapping_{shl, shr}`
+    // Verify `wrapping_{shl, shr}` which internally uses `unchecked_{shl,shr}`
     macro_rules! generate_wrapping_shift_harness {
         ($type:ty, $method:ident, $harness_name:ident) => {
             #[kani::proof_for_contract($type::$method)]

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1645,19 +1645,6 @@ mod verify {
         }
     }
 
-    // Verify `wrapping_{shl, shr}` which internally uses `unchecked_{shl,shr}`
-    macro_rules! generate_wrapping_shift_harness {
-        ($type:ty, $method:ident, $harness_name:ident) => {
-            #[kani::proof_for_contract($type::$method)]
-            pub fn $harness_name() {
-                let num1: $type = kani::any::<$type>();
-                let num2: u32 = kani::any::<u32>();
-
-                let _ = num1.$method(num2);
-            }
-        }
-    }
-
     macro_rules! generate_unchecked_neg_harness {
         ($type:ty, $harness_name:ident) => {
             #[kani::proof_for_contract($type::unchecked_neg)]
@@ -1697,6 +1684,19 @@ mod verify {
                     assert_eq!(result_high, expected_high);
                 }
             )+
+        }
+    }
+
+    // Verify `wrapping_{shl, shr}` which internally uses `unchecked_{shl,shr}`
+    macro_rules! generate_wrapping_shift_harness {
+        ($type:ty, $method:ident, $harness_name:ident) => {
+            #[kani::proof_for_contract($type::$method)]
+            pub fn $harness_name() {
+                let num1: $type = kani::any::<$type>();
+                let num2: u32 = kani::any::<u32>();
+
+                let _ = num1.$method(num2);
+            }
         }
     }
 
@@ -1928,7 +1928,7 @@ mod verify {
     // #[ensures(|result| *result == self << (rhs & (Self::BITS - 1)))]
     //
     // Target function:
-    // pub const fn wrapping_shl(self, rhs: u32) -> Self {
+    // pub const fn wrapping_shl(self, rhs: u32) -> Self
     //
     // This function performs an panic-free bitwise left shift operation.
     generate_wrapping_shift_harness!(i8, wrapping_shl, checked_wrapping_shl_i8);

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1645,6 +1645,19 @@ mod verify {
         }
     }
 
+    // Verify `wrapping_{shl, shr}`
+    macro_rules! generate_wrapping_shift_harness {
+        ($type:ty, $method:ident, $harness_name:ident) => {
+            #[kani::proof_for_contract($type::$method)]
+            pub fn $harness_name() {
+                let num1: $type = kani::any::<$type>();
+                let num2: u32 = kani::any::<u32>();
+
+                let _ = num1.$method(num2);
+            }
+        }
+    }
+
     macro_rules! generate_unchecked_neg_harness {
         ($type:ty, $harness_name:ident) => {
             #[kani::proof_for_contract($type::unchecked_neg)]
@@ -1849,4 +1862,30 @@ mod verify {
     generate_unchecked_math_harness!(u64, unchecked_sub, checked_unchecked_sub_u64);
     generate_unchecked_math_harness!(u128, unchecked_sub, checked_unchecked_sub_u128);
     generate_unchecked_math_harness!(usize, unchecked_sub, checked_unchecked_sub_usize);
+
+    // `wrapping_shl` proofs
+    //
+    // Target types:
+    // i{8,16,32,64,128,size} and u{8,16,32,64,128,size} -- 12 types in total
+    //
+    // Target contracts:
+    // #[requires(rhs < Self::BITS)]
+    // #[ensures(|result| *result == self << (rhs & (Self::BITS - 1)))]
+    //
+    // Target function:
+    // pub const fn wrapping_shl(self, rhs: u32) -> Self {
+    //
+    // This function performs an panic-free bitwise left shift operation.
+    generate_wrapping_shift_harness!(i8, wrapping_shl, checked_wrapping_shl_i8);
+    generate_wrapping_shift_harness!(i16, wrapping_shl, checked_wrapping_shl_i16);
+    generate_wrapping_shift_harness!(i32, wrapping_shl, checked_wrapping_shl_i32);
+    generate_wrapping_shift_harness!(i64, wrapping_shl, checked_wrapping_shl_i64);
+    generate_wrapping_shift_harness!(i128, wrapping_shl, checked_wrapping_shl_i128);
+    generate_wrapping_shift_harness!(isize, wrapping_shl, checked_wrapping_shl_isize);
+    generate_wrapping_shift_harness!(u8, wrapping_shl, checked_wrapping_shl_u8);
+    generate_wrapping_shift_harness!(u16, wrapping_shl, checked_wrapping_shl_u16);
+    generate_wrapping_shift_harness!(u32, wrapping_shl, checked_wrapping_shl_u32);
+    generate_wrapping_shift_harness!(u64, wrapping_shl, checked_wrapping_shl_u64);
+    generate_wrapping_shift_harness!(u128, wrapping_shl, checked_wrapping_shl_u128);
+    generate_wrapping_shift_harness!(usize, wrapping_shl, checked_wrapping_shl_usize);
 }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2138,6 +2138,11 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        // Precondition: The right hand side of the shift (rhs) is less than
+        // the number of bits in the type. This prevents undefined behavior.
+        // TODO: Is requires needed? It's already specified in `unchecked_shl`
+        #[requires(rhs < Self::BITS)]
+        #[ensures(|result| *result == self << (rhs & (Self::BITS - 1)))]
         pub const fn wrapping_shl(self, rhs: u32) -> Self {
             // SAFETY: the masking by the bitsize of the type ensures that we do not shift
             // out of bounds

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2138,10 +2138,6 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         #[rustc_allow_const_fn_unstable(unchecked_shifts)]
-        // Precondition: The right hand side of the shift (rhs) is less than
-        // the number of bits in the type. This prevents undefined behavior.
-        // TODO: Is requires needed? It's already specified in `unchecked_shl`
-        #[requires(rhs < Self::BITS)]
         #[ensures(|result| *result == self << (rhs & (Self::BITS - 1)))]
         pub const fn wrapping_shl(self, rhs: u32) -> Self {
             // SAFETY: the masking by the bitsize of the type ensures that we do not shift


### PR DESCRIPTION
Towards #59 

### Changes
* Added contracts for `wrapping_shl` (located in `library/core/src/num/int_macros.rs` and `uint_macros.rs`)
* Added a macro for generating wrapping_{shl, shr} harnesses
* Added harnesses for `wrapping_shl` of each integer type
  * `i8`, `i16`, `i32`, `i64`, `i128`, `isize`, `u8`, `u16`, `u32`, `u64`, `u128`, `usize` --- 12 harnesses in total.

### Revalidation
1. Per the discussion in #59, we have to **build and run Kani from `feature/verify-rust-std` branch**.
2. To revalidate the verification results, run the following command. `<harness_to_run>` can be either `num::verify` to run all harnesses or `num::verify::<harness_name>` (e.g. `checked_wrapping_shl_i8`) to run a specific harness.
```
kani verify-std  "path/to/library" \
    --harness <harness_to_run> \
    -Z unstable-options \
    -Z function-contracts \
    -Z mem-predicates
```

All harnesses should pass the default checks (1251 checks where 1 unreachable).
```
SUMMARY:
 ** 0 of 1251 failed (1 unreachable)

VERIFICATION:- SUCCESSFUL
Verification Time: 2.4682913s

Complete - 1 successfully verified harnesses, 0 failures, 1 total.
```
Example of the unreachable check:
```
Check 123: num::<impl i8>::wrapping_shl.assertion.1
         - Status: UNREACHABLE
         - Description: "attempt to subtract with overflow"
         - Location: library/core/src/num/int_macros.rs:2172:42 in function num::<impl i8>::wrapping_shl
```

### Questions
1. Should we add `requires` (and `ensures`) for `wrapping_shl` given that `unchecked_shl` already has a `requires`?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
