### PR TITLE
Add loop contracts and harness for `BinaryHeap::sift_up`

### DIFF
--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 
 [dependencies]
 core = { path = "../core" }
+safety = { path = "../contracts/safety" }
 compiler_builtins = { version = "0.1.123", features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]

--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -155,7 +155,7 @@ use crate::collections::TryReserveError;
 use crate::slice;
 use crate::vec::{self, AsVecIntoIter, Vec};
 
-use safety::{ensures, requires};
+use safety::requires;
 
 #[cfg(kani)]
 #[unstable(feature="kani", issue="none")]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -192,6 +192,8 @@
 #![feature(unboxed_closures)]
 #![feature(unsized_fn_params)]
 #![feature(with_negative_coherence)]
+#![cfg_attr(kani, feature(proc_macro_hygiene))]
+#![cfg_attr(kani, feature(kani))]
 #![rustc_preserve_ub_checks]
 // tidy-alphabetical-end
 //

--- a/scripts/check_kani.sh
+++ b/scripts/check_kani.sh
@@ -44,7 +44,8 @@ cargo build-dev --release
 echo "Running tests..."
 echo
 cd "$VERIFY_RUST_STD_DIR"
-$KANI_DIR/scripts/kani verify-std -Z unstable-options $VERIFY_RUST_STD_DIR/library --target-dir "$RUNNER_TEMP" -Z function-contracts -Z mem-predicates
+$KANI_DIR/scripts/kani verify-std -Z unstable-options $VERIFY_RUST_STD_DIR/library --target-dir "$RUNNER_TEMP" -Z function-contracts -Z mem-predicates -Z loop-contracts --enable-unstable --cbmc-args --object-bits 8
+
 
 echo "Tests completed."
 echo


### PR DESCRIPTION
This proof is blocked as CBMC couldn't infer the loop modifies `hole.pos`. We need to add support of loop modifies or improve CBMC's inference algorithm.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
