### PR TITLE
Fix tool template link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ See [the Rust repository](https://github.com/rust-lang/rust) for details.
 
 ## Introducing a New Tool
 
-Please use the [template available in this repository](.github/TOOL_REQUEST_TEMPLATE.md) to introduce a new verification tool.
+Please use the [template available in this repository](./doc/src/tool_template.md) to introduce a new verification tool.


### PR DESCRIPTION
To test that the link works, navigate to [my fork](https://github.com/carolynzech/verify-rust-std/tree/fix-readme) and click the tool template link in the README.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
