### PR TITLE
Contracts & Harnesses for `f32::to_int_unchecked`

### DIFF
--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -17,6 +17,11 @@ use crate::intrinsics;
 use crate::mem;
 use crate::num::FpCategory;
 
+use safety::{requires, ensures};
+
+#[cfg(kani)]
+use crate::kani;
+
 /// The radix or base of the internal representation of `f32`.
 /// Use [`f32::RADIX`] instead.
 ///
@@ -1086,6 +1091,8 @@ impl f32 {
                   without modifying the original"]
     #[stable(feature = "float_approx_unchecked_to", since = "1.44.0")]
     #[inline]
+    #[requires(!self.is_nan() && !self.is_infinite())]
+    #[requires(self >= Self::MIN && self <= Self::MAX)]
     pub unsafe fn to_int_unchecked<Int>(self) -> Int
     where
         Self: FloatToInt<Int>,

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1091,8 +1091,8 @@ impl f32 {
                   without modifying the original"]
     #[stable(feature = "float_approx_unchecked_to", since = "1.44.0")]
     #[inline]
-    #[requires(!self.is_nan() && !self.is_infinite())]
-    #[requires(self >= Self::MIN && self <= Self::MAX)]
+    // is_finite() checks if the given float is neither infinite nor NaN.
+    #[requires(self.is_finite() && self >= Self::MIN && self <= Self::MAX)]
     pub unsafe fn to_int_unchecked<Int>(self) -> Int
     where
         Self: FloatToInt<Int>,

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1590,7 +1590,7 @@ from_str_radix_size_impl! { i64 isize, u64 usize }
 #[unstable(feature = "kani", issue = "none")]
 mod verify {
     use super::*;
-
+/*
     // Verify `unchecked_{add, sub, mul}`
     macro_rules! generate_unchecked_math_harness {
         ($type:ty, $method:ident, $harness_name:ident) => {
@@ -1967,4 +1967,14 @@ mod verify {
     generate_wrapping_shift_harness!(u64, wrapping_shr, checked_wrapping_shr_u64);
     generate_wrapping_shift_harness!(u128, wrapping_shr, checked_wrapping_shr_u128);
     generate_wrapping_shift_harness!(usize, wrapping_shr, checked_wrapping_shr_usize);
+*/
+
+    #[kani::proof_for_contract(f32::to_int_unchecked)]
+    pub fn checked_to_int_unchecked_f32() {
+        let num1: f32 = kani::any::<f32>();
+
+        let result = unsafe { num1.to_int_unchecked::<i32>() };
+
+        assert_eq!(result, num1 as i32);
+    }
 }


### PR DESCRIPTION
Towards #59 
❗ Depends on [this WIP Kani Issue](https://github.com/model-checking/kani/issues/3629), as discussed in [this thread](https://github.com/model-checking/verify-rust-std/issues/59#issuecomment-2428184293) in Challenge Issue

### Changes
* Added contracts for `f32::to_int_unchecked` (located in `library/core/src/num/f32.rs`)
* Added a macro for generating `to_int_unchecked` harnesses
* Added harnesses for `to_int_unchecked` of each integer type
  * `i8`, `i16`, `i32`, `i64`, `i128`, `isize`, `u8`, `u16`, `u32`, `u64`, `u128`, `usize` --- 12 harnesses in total.

### Revalidation
1. Per the discussion in #59, we have to **build and run Kani from `feature/verify-rust-std` branch**.
2. To revalidate the verification results, run the following command. `<harness_to_run>` can be either `num::verify` to run all harnesses or `num::verify::<harness_name>` (e.g. `checked_f32_to_int_unchecked_i8`) to run a specific harness.
```
kani verify-std  "path/to/library" \
    --harness <harness_to_run> \
    -Z unstable-options \
    -Z function-contracts \
    -Z mem-predicates
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
