### PR TITLE
Update Kani version

### DIFF
--- a/tool_config/kani-version.toml
+++ b/tool_config/kani-version.toml
@@ -2,4 +2,4 @@
 # incompatible with the verify-std repo.
 
 [kani]
-commit = "8400296f5280be4f99820129bc66447e8dff63f4"
+commit = "26c078e097025499baf6e360210a21989d3605e0"


### PR DESCRIPTION
Update to the version where the CBMC viewer is removed. This should resolve the issues some people are having with the `run_kani.sh` script.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
