### PR TITLE
Contracts and Harnesses for `<*const T>::byte_add`, `byte_sub` and `byte_offset`

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -471,14 +471,14 @@ impl<T: ?Sized> *const T {
         // bytes doesn't cause overflow and that both pointers `self` and the result
         // are pointing to the same address or in the same allocation
         (mem::size_of_val_raw(self) != 0 &&
-            (self as *mut u8 as isize).checked_add(count).is_some() &&
-            ((self as *mut u8 as usize) == (self.wrapping_byte_offset(count) as *mut u8 as usize) ||
-                kani::mem::same_allocation(self as *const T, self.wrapping_byte_offset(count) as *const T)))
+            (self as *const u8 as isize).checked_add(count).is_some() &&
+            ((self as *const u8 as usize) == (self.wrapping_byte_offset(count) as *const u8 as usize) ||
+                kani::mem::same_allocation(self, self.wrapping_byte_offset(count))))
     )]
     #[ensures(|result|
         // The resulting pointer should either be unchanged or still point to the same allocation
-        ((self as *mut u8 as usize) == (*result as *mut u8 as usize)) ||
-        (kani::mem::same_allocation(self as *const T, *result as *const T))
+        ((self as *const u8 as usize) == (*result as *const u8 as usize)) ||
+        (kani::mem::same_allocation(self, *result))
     )]
     pub const unsafe fn byte_offset(self, count: isize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `offset`.
@@ -1000,14 +1000,14 @@ impl<T: ?Sized> *const T {
         // bytes doesn't cause overflow and that both pointers `self` and the result
         // are pointing to the same address or in the same allocation
         (mem::size_of_val_raw(self) != 0 &&
-            (self as *mut u8 as isize).checked_add(count as isize).is_some() &&
-            ((self as *mut u8 as usize) == (self.wrapping_byte_add(count) as *mut u8 as usize) ||
-                kani::mem::same_allocation(self as *const T, self.wrapping_byte_add(count) as *const T)))
+            (self as *const u8 as isize).checked_add(count as isize).is_some() &&
+            ((self as *const u8 as usize) == (self.wrapping_byte_add(count) as *const u8 as usize) ||
+                kani::mem::same_allocation(self, self.wrapping_byte_add(count))))
     )]
     #[ensures(|result|
         // The resulting pointer should either be unchanged or still point to the same allocation
-        ((self as *mut u8 as usize) == (*result as *mut u8 as usize)) ||
-        (kani::mem::same_allocation(self as *const T, *result as *const T))
+        ((self as *const u8 as usize) == (*result as *const u8 as usize)) ||
+        (kani::mem::same_allocation(self, *result))
     )]
     pub const unsafe fn byte_add(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `add`.
@@ -1131,14 +1131,14 @@ impl<T: ?Sized> *const T {
         // bytes doesn't cause overflow and that both pointers `self` and the result
         // would be pointing to the same address or in the same allocation
         (mem::size_of_val_raw(self) != 0 &&
-            (self as *mut u8 as isize).checked_sub(count as isize).is_some() &&
-            ((self as *mut u8 as usize) == (self.wrapping_byte_sub(count) as *mut u8 as usize) ||
-                kani::mem::same_allocation(self as *const T, self.wrapping_byte_sub(count) as *const T)))
+            (self as *const u8 as isize).checked_sub(count as isize).is_some() &&
+            ((self as *const u8 as usize) == (self.wrapping_byte_sub(count) as *const u8 as usize) ||
+                kani::mem::same_allocation(self, self.wrapping_byte_sub(count))))
     )]
     #[ensures(|result|
          // The resulting pointer should either be unchanged or still point to the same allocation
-        ((self as *mut u8 as isize) == (*result as *mut u8 as isize)) ||
-        (kani::mem::same_allocation(self as *const T, *result as *const T))
+        ((self as *const u8 as isize) == (*result as *const u8 as isize)) ||
+        (kani::mem::same_allocation(self, *result))
     )]
     pub const unsafe fn byte_sub(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `sub`.

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1998,7 +1998,6 @@ pub mod verify {
     // bounding space for PointerGenerator to accommodate 40 elements.
     const ARRAY_LEN: usize = 40;
 
-
     // generate proof for contracts for byte_add, byte_sub and byte_offset
     // - `$type`: pointee type
     // - `$fn_name`: function for which the contract must be verified
@@ -2108,7 +2107,11 @@ pub mod verify {
     gen_const_byte_arith_harness!(usize, byte_offset, check_const_byte_offset_usize);
     gen_const_byte_arith_harness!((i8, i8), byte_offset, check_const_byte_offset_tuple_1);
     gen_const_byte_arith_harness!((f64, bool), byte_offset, check_const_byte_offset_tuple_2);
-    gen_const_byte_arith_harness!((i32, f64, bool), byte_offset, check_const_byte_offset_tuple_3);
+    gen_const_byte_arith_harness!(
+        (i32, f64, bool),
+        byte_offset,
+        check_const_byte_offset_tuple_3
+    );
     gen_const_byte_arith_harness!(
         (i8, u16, i32, u64, isize),
         byte_offset,
@@ -2179,11 +2182,19 @@ pub mod verify {
     gen_const_byte_arith_harness_for_slice!(i32, byte_offset, check_const_byte_offset_i32_slice);
     gen_const_byte_arith_harness_for_slice!(i64, byte_offset, check_const_byte_offset_i64_slice);
     gen_const_byte_arith_harness_for_slice!(i128, byte_offset, check_const_byte_offset_i128_slice);
-    gen_const_byte_arith_harness_for_slice!(isize, byte_offset, check_const_byte_offset_isize_slice);
+    gen_const_byte_arith_harness_for_slice!(
+        isize,
+        byte_offset,
+        check_const_byte_offset_isize_slice
+    );
     gen_const_byte_arith_harness_for_slice!(u8, byte_offset, check_const_byte_offset_u8_slice);
     gen_const_byte_arith_harness_for_slice!(u16, byte_offset, check_const_byte_offset_u16_slice);
     gen_const_byte_arith_harness_for_slice!(u32, byte_offset, check_const_byte_offset_u32_slice);
     gen_const_byte_arith_harness_for_slice!(u64, byte_offset, check_const_byte_offset_u64_slice);
     gen_const_byte_arith_harness_for_slice!(u128, byte_offset, check_const_byte_offset_u128_slice);
-    gen_const_byte_arith_harness_for_slice!(usize, byte_offset, check_const_byte_offset_usize_slice);
+    gen_const_byte_arith_harness_for_slice!(
+        usize,
+        byte_offset,
+        check_const_byte_offset_usize_slice
+    );
 }


### PR DESCRIPTION
Towards https://github.com/model-checking/verify-rust-std/issues/76

### Changes

* Adds contracts for `<*mut T>::byte_add`, `<*mut T>::byte_sub` and `<*mut T>::byte_offset`.
* Adds harnesses for the function verifying the following pointee types:
  * All integer types
  * Tuples (composite types)
  * Unit Type
  * Slices
* Accomplishes this using a few macros.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.