### PR TITLE
docs(0005): typo fix in the challenge docs

### DIFF
--- a/doc/src/challenges/0005-linked-list.md
+++ b/doc/src/challenges/0005-linked-list.md
@@ -23,7 +23,7 @@ The memory safety of the following public functions that iterating over the inte
 
 | Function | Location |
 |---------|---------|
-|clearn | alloc::collections::linked_list |
+|clear | alloc::collections::linked_list |
 |contains| alloc::collections::linked_list |
 |split_off| alloc::collections::linked_list |
 |remove| alloc::collections::linked_list |

--- a/doc/src/challenges/0005-linked-list.md
+++ b/doc/src/challenges/0005-linked-list.md
@@ -23,7 +23,7 @@ The memory safety of the following public functions that iterating over the inte
 
 | Function | Location |
 |---------|---------|
-|clear | alloc::collections::linked_list |
+|clear| alloc::collections::linked_list |
 |contains| alloc::collections::linked_list |
 |split_off| alloc::collections::linked_list |
 |remove| alloc::collections::linked_list |


### PR DESCRIPTION
This PR, just fixes a typo for a function name in the challenge docs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
