### PR TITLE
CStr Safety invariant & Harnesses for `from_bytes_until_nul`

### DIFF
--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -863,10 +863,18 @@ mod verify {
     use super::*;
 
     // pub const fn from_bytes_until_nul(bytes: &[u8]) -> Result<&CStr, FromBytesUntilNulError>
+    // Check 1: A random index in a u8 array is guaranteed to be a null byte
+    // Check 2: Only the last byte of a u8 array is a null byte
+    // Check 3: The first byte of a u8 array is a null byte
+    //
+    // Proofs are bounded (kani::unwind) by the length of the input array.
+    // Check 1: 2.08 sec when 32; 7.49 sec when 40
+    // Check 2: 6.72 sec when 32; 9.2 sec when 40
+    // Check 3: 0.33 sec when 8; 2.06 sec when 16
     #[kani::proof]
-    #[kani::unwind(32)]  // Proof bounded by array length
+    #[kani::unwind(32)]
     fn check_from_bytes_until_nul_random_nul_byte() {
-        const ARR_LEN: usize = 1000;
+        const ARR_LEN: usize = 32;
         let mut string: [u8; ARR_LEN] = kani::any();
 
         // ensure that there is at least one null byte
@@ -878,10 +886,11 @@ mod verify {
     }
 
     #[kani::proof]
-    #[kani::unwind(32)]  // Proof bounded by array length
+    #[kani::unwind(32)]
     fn check_from_bytes_until_nul_single_nul_byte_end() {
-        const ARR_LEN: usize = 1000;
+        const ARR_LEN: usize = 32;
         // ensure that the string does not have intermediate null bytes
+        // TODO: there might be a better way
         let mut string: [u8; ARR_LEN] = kani::any_where(|x: &[u8; ARR_LEN]| !x[..ARR_LEN-1].contains(&0));
         // ensure that the string is properly null-terminated
         string[ARR_LEN - 1] = 0;
@@ -891,9 +900,9 @@ mod verify {
     }
 
     #[kani::proof]
-    #[kani::unwind(8)]  // Proof bounded by array length
+    #[kani::unwind(16)]
     fn check_from_bytes_until_nul_single_nul_byte_head() {
-        const ARR_LEN: usize = 8;
+        const ARR_LEN: usize = 16;
         let mut string: [u8; ARR_LEN] = kani::any();
         // The first byte is a null byte should result in an empty CStr.
         string[0] = 0;

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -9,6 +9,11 @@ use crate::ptr::NonNull;
 use crate::slice::memchr;
 use crate::{fmt, intrinsics, ops, slice, str};
 
+// use safety::{requires, ensures};
+
+#[cfg(kani)]
+use crate::kani;
+
 // FIXME: because this is doc(inline)d, we *have* to use intra-doc links because the actual link
 //   depends on where the item is being documented. however, since this is libcore, we can't
 //   actually reference libstd or liballoc in intra-doc links. so, the best we can do is remove the
@@ -100,6 +105,9 @@ use crate::{fmt, intrinsics, ops, slice, str};
 // want `repr(transparent)` but we don't want it to show up in rustdoc, so we hide it under
 // `cfg(doc)`. This is an ad-hoc implementation of attribute privacy.
 #[repr(transparent)]
+#[derive(kani::Arbitrary)]
+#[derive(kani::Invariant)]
+#[safety_constraint(inner.len() > 0 && inner[inner.len() - 1] == 0 && !inner[..inner.len() - 1].contains(&0))]
 pub struct CStr {
     // FIXME: this should not be represented with a DST slice but rather with
     //        just a raw `c_char` along with some form of marker to make

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -9,7 +9,6 @@ use crate::ptr::NonNull;
 use crate::slice::memchr;
 use crate::{fmt, intrinsics, ops, slice, str};
 
-// use safety::{requires, ensures};
 use crate::ub_checks::Invariant;
 
 #[cfg(kani)]
@@ -217,7 +216,7 @@ impl fmt::Display for FromBytesWithNulError {
 impl Invariant for &CStr {
     /**
      * Safety invariant of a valid CStr:
-     * 1. An empty CStr should has a null byte.
+     * 1. An empty CStr should have a null byte.
      * 2. A valid CStr should end with a null-terminator and contains
      *    no intermediate null bytes.
      */
@@ -225,11 +224,7 @@ impl Invariant for &CStr {
         let bytes: &[c_char] = &self.inner;
         let len = bytes.len();
 
-        if bytes.is_empty() || bytes[len - 1] != 0 || bytes[..len-1].contains(&0) {
-            return false;
-        }
-
-        true
+        return !bytes.is_empty() && bytes[len - 1] == 0 && !bytes[..len-1].contains(&0);
     }
 }
 

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -224,7 +224,7 @@ impl Invariant for &CStr {
         let bytes: &[c_char] = &self.inner;
         let len = bytes.len();
 
-        return !bytes.is_empty() && bytes[len - 1] == 0 && !bytes[..len-1].contains(&0);
+        !bytes.is_empty() && bytes[len - 1] == 0 && !bytes[..len-1].contains(&0)
     }
 }
 

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -20,11 +20,6 @@ pub use self::c_str::FromBytesUntilNulError;
 pub use self::c_str::FromBytesWithNulError;
 use crate::fmt;
 
-use safety::{requires, ensures};
-
-#[cfg(kani)]
-use crate::kani;
-
 #[unstable(feature = "c_str_module", issue = "112134")]
 pub mod c_str;
 
@@ -228,24 +223,3 @@ impl fmt::Debug for c_void {
 )]
 #[link(name = "/defaultlib:libcmt", modifiers = "+verbatim", cfg(target_feature = "crt-static"))]
 extern "C" {}
-
-#[cfg(kani)]
-#[unstable(feature = "kani", issue = "none")]
-mod verify {
-    use super::*;
-
-    // pub const fn from_bytes_until_nul(bytes: &[u8]) -> Result<&CStr, FromBytesUntilNulError>
-    #[kani::proof]
-    #[kani::unwind(16)]  // Proof bounded by array length
-    fn check_from_bytes_until_nul() {
-        const ARR_LEN: usize = 16;
-        let mut string: [u8; ARR_LEN] = kani::any();
-        // ensure that there is at least one null byte
-        let idx: usize = kani::any_where(|x| *x >= 0 && *x < ARR_LEN);
-        string[idx] = 0;
-
-        let c_str = CStr::from_bytes_until_nul(&string).unwrap();
-        assert!(c_str.is_safe());
-    }
-
-}

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -20,6 +20,11 @@ pub use self::c_str::FromBytesUntilNulError;
 pub use self::c_str::FromBytesWithNulError;
 use crate::fmt;
 
+use safety::{requires, ensures};
+
+#[cfg(kani)]
+use crate::kani;
+
 #[unstable(feature = "c_str_module", issue = "112134")]
 pub mod c_str;
 
@@ -223,3 +228,24 @@ impl fmt::Debug for c_void {
 )]
 #[link(name = "/defaultlib:libcmt", modifiers = "+verbatim", cfg(target_feature = "crt-static"))]
 extern "C" {}
+
+#[cfg(kani)]
+#[unstable(feature = "kani", issue = "none")]
+mod verify {
+    use super::*;
+
+    // pub const fn from_bytes_until_nul(bytes: &[u8]) -> Result<&CStr, FromBytesUntilNulError>
+    #[kani::proof]
+    #[kani::unwind(16)]  // Proof bounded by array length
+    fn check_from_bytes_until_nul() {
+        const ARR_LEN: usize = 16;
+        let mut string: [u8; ARR_LEN] = kani::any();
+        // ensure that there is at least one null byte
+        let idx: usize = kani::any_where(|x| *x >= 0 && *x < ARR_LEN);
+        string[idx] = 0;
+
+        let c_str = CStr::from_bytes_until_nul(&string).unwrap();
+        assert!(c_str.is_safe());
+    }
+
+}


### PR DESCRIPTION
Towards #150 

### Changes
* Added a `CStr` Safety Invariant
* Added a harness for `from_bytes_until_nul`, the harness covers:
    * The input slice contains a single null byte at the end;
    * The input slice contains no null bytes;
    * The input slice contains intermediate null bytes

### Discussion
* [Safety invariant implementation](https://github.com/model-checking/verify-rust-std/issues/150#issuecomment-2492853570)
* [Input array generation](https://github.com/model-checking/verify-rust-std/discussions/181)

### Verification Result
`./scripts/run-kani.sh --kani-args --harness ffi::c_str::verify`

```
// array size 16
Checking harness ffi::c_str::verify::check_from_bytes_until_nul...

VERIFICATION RESULT:
 ** 0 of 140 failed (5 unreachable)

VERIFICATION:- SUCCESSFUL
Verification Time: 7.3023376s

Complete - 1 successfully verified harnesses, 0 failures, 1 total.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
