### PR TITLE
Harnesses for `to_bytes` and `to_bytes_with_nul`

### DIFF
--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -875,4 +875,42 @@ mod verify {
             assert!(c_str.is_safe());
         }
     }
+
+    // pub const fn to_bytes(&self) -> &[u8]
+    #[kani::proof]
+    #[kani::unwind(32)]
+    fn check_to_bytes() {
+        const MAX_SIZE: usize = 32;
+        let string: [u8; MAX_SIZE] = kani::any();
+        let slice = kani::slice::any_slice_of_array(&string);
+
+        let result = CStr::from_bytes_until_nul(slice);
+        if let Ok(c_str) = result {
+            // Find the index of the first null byte in the slice since
+            // from_bytes_until_nul stops by there
+            let end_idx = slice.iter().position(|x| *x == 0).unwrap();
+            // Comparison does not include the null byte
+            assert_eq!(c_str.to_bytes(), &slice[..end_idx]);
+            assert!(c_str.is_safe());
+        }
+    }
+
+    // pub const fn to_bytes_with_nul(&self) -> &[u8]
+    #[kani::proof]
+    #[kani::unwind(33)] // 101.7 seconds when 33; 17.9 seconds for 17
+    fn check_to_bytes_with_nul() {
+        const MAX_SIZE: usize = 32;
+        let string: [u8; MAX_SIZE] = kani::any();
+        let slice = kani::slice::any_slice_of_array(&string);
+
+        let result = CStr::from_bytes_until_nul(slice);
+        if let Ok(c_str) = result {
+            // Find the index of the first null byte in the slice since
+            // from_bytes_until_nul stops by there
+            let end_idx = slice.iter().position(|x| *x == 0).unwrap();
+            // Comparison includes the null byte
+            assert_eq!(c_str.to_bytes_with_nul(), &slice[..end_idx + 1]);
+            assert!(c_str.is_safe());
+        }
+    }
 }


### PR DESCRIPTION
Towards #150 

### Changes
* Added harnesses for `to_bytes` and `to_bytes_with_nul`
* Added a small fix to `count_bytes`

Verification Result:
```
Checking harness ffi::c_str::verify::check_to_bytes_with_nul...

VERIFICATION RESULT:
 ** 0 of 179 failed (5 unreachable)

VERIFICATION:- SUCCESSFUL
Verification Time: 88.397385s

Checking harness ffi::c_str::verify::check_to_bytes...

VERIFICATION RESULT:
 ** 0 of 180 failed (5 unreachable)

VERIFICATION:- SUCCESSFUL
Verification Time: 79.66312s

Checking harness ffi::c_str::verify::check_from_bytes_until_nul...

VERIFICATION RESULT:
 ** 0 of 132 failed (5 unreachable)

VERIFICATION:- SUCCESSFUL
Verification Time: 28.593569s

Complete - 3 successfully verified harnesses, 0 failures, 3 total.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
