### PR TITLE
NonZero (max & min) Proof

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -2265,3 +2265,89 @@ mod verify {
     nonzero_check!(u128, core::num::NonZeroU128, nonzero_check_new_unchecked_for_u128);
     nonzero_check!(usize, core::num::NonZeroUsize, nonzero_check_new_unchecked_for_usize);
 }
+
+#[cfg(kani)]
+mod macro_nonzero_check_max {
+    use super::*;
+    macro_rules! nonzero_check_max {
+        ($t:ty, $nonzero_type:ty, $nonzero_check_max_for:ident) => {
+            #[kani::proof]
+            pub fn $nonzero_check_max_for() {
+                let x: $t = kani::any();
+                kani::assume(x != 0);
+                let y: $t = kani::any();
+                kani::assume(y != 0);
+            
+                unsafe {
+                    let x = <$nonzero_type>::new_unchecked(x);
+                    let y = <$nonzero_type>::new_unchecked(y);
+                }
+            
+                // Use the max function and check the result
+                let result = x.max(y);
+                if x > y {
+                    assert!(result == x);
+                } else {
+                    assert!(result == y);
+                }
+            }
+        };
+    }
+
+    // Use the macro to generate different versions of the function for multiple types
+    nonzero_check_max!(i8, core::num::NonZeroI8, nonzero_check_max_for_i8);
+    nonzero_check_max!(i16, core::num::NonZeroI16, nonzero_check_max_for_16);
+    nonzero_check_max!(i32, core::num::NonZeroI32, nonzero_check_max_for_32);
+    nonzero_check_max!(i64, core::num::NonZeroI64, nonzero_check_max_for_64);
+    nonzero_check_max!(i128, core::num::NonZeroI128, nonzero_check_max_for_128);
+    nonzero_check_max!(isize, core::num::NonZeroIsize, nonzero_check_max_for_isize);
+    nonzero_check_max!(u8, core::num::NonZeroU8, nonzero_check_max_for_u8);
+    nonzero_check_max!(u16, core::num::NonZeroU16, nonzero_check_max_for_u16);
+    nonzero_check_max!(u32, core::num::NonZeroU32, nonzero_check_max_for_u32);
+    nonzero_check_max!(u64, core::num::NonZeroU64, nonzero_check_max_for_u64);
+    nonzero_check_max!(u128, core::num::NonZeroU128, nonzero_check_max_for_u128);
+    nonzero_check_max!(usize, core::num::NonZeroUsize, nonzero_check_max_for_usize);
+}
+
+#[cfg(kani)]
+mod macro_nonzero_check_min {
+    use super::*;
+    macro_rules! nonzero_check_min {
+        ($t:ty, $nonzero_type:ty, $nonzero_check_min_for:ident) => {
+            #[kani::proof]
+            pub fn $nonzero_check_min_for() {
+                let x: $t = kani::any();
+                kani::assume(x != 0);
+                let y: $t = kani::any();
+                kani::assume(y != 0);
+            
+                unsafe {
+                    let x = <$nonzero_type>::new_unchecked(x);
+                    let y = <$nonzero_type>::new_unchecked(y);
+                }
+            
+                // Use the min function and check the result
+                let result = x.min(y);
+                if x < y {
+                    assert!(result == x);
+                } else {
+                    assert!(result == y);
+                }
+            }
+        };
+    }
+
+    // Use the macro to generate different versions of the function for multiple types
+    nonzero_check_min!(i8, core::num::NonZeroI8, nonzero_check_min_for_i8);
+    nonzero_check_min!(i16, core::num::NonZeroI16, nonzero_check_min_for_16);
+    nonzero_check_min!(i32, core::num::NonZeroI32, nonzero_check_min_for_32);
+    nonzero_check_min!(i64, core::num::NonZeroI64, nonzero_check_min_for_64);
+    nonzero_check_min!(i128, core::num::NonZeroI128, nonzero_check_min_for_128);
+    nonzero_check_min!(isize, core::num::NonZeroIsize, nonzero_check_min_for_isize);
+    nonzero_check_min!(u8, core::num::NonZeroU8, nonzero_check_min_for_u8);
+    nonzero_check_min!(u16, core::num::NonZeroU16, nonzero_check_min_for_u16);
+    nonzero_check_min!(u32, core::num::NonZeroU32, nonzero_check_min_for_u32);
+    nonzero_check_min!(u64, core::num::NonZeroU64, nonzero_check_min_for_u64);
+    nonzero_check_min!(u128, core::num::NonZeroU128, nonzero_check_min_for_u128);
+    nonzero_check_min!(usize, core::num::NonZeroUsize, nonzero_check_min_for_usize);
+}

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -2270,78 +2270,64 @@ mod verify {
 mod macro_nonzero_check_max {
     use super::*;
     macro_rules! nonzero_check_max {
-        ($t:ty, $nonzero_type:ty, $nonzero_check_max_for:ident) => {
+        ($nonzero_type:ty, $nonzero_check_max_for:ident) => {
             #[kani::proof]
             pub fn $nonzero_check_max_for() {
-                let int_x: $t = kani::any();
-                kani::assume(int_x != 0);
-                let int_y: $t = kani::any();
-                kani::assume(int_y != 0);   
-                unsafe {
-                    let x = <$nonzero_type>::new_unchecked(int_x);
-                    let y = <$nonzero_type>::new_unchecked(int_y);
-                    let result = x.max(y);
-                    if x > y {
-                        assert!(result == x);
-                    } else {
-                        assert!(result == y);
-                    }
-                }      
+                let x: $nonzero_type = kani::any();
+                let y: $nonzero_type = kani::any();
+                let result = x.max(y);
+                if x > y {
+                    assert!(result == x);
+                } else {
+                    assert!(result == y);
+                }
             }
         };
     }
 
-    // Use the macro to generate different versions of the function for multiple types
-    nonzero_check_max!(i8, core::num::NonZeroI8, nonzero_check_max_for_i8);
-    nonzero_check_max!(i16, core::num::NonZeroI16, nonzero_check_max_for_16);
-    nonzero_check_max!(i32, core::num::NonZeroI32, nonzero_check_max_for_32);
-    nonzero_check_max!(i64, core::num::NonZeroI64, nonzero_check_max_for_64);
-    nonzero_check_max!(i128, core::num::NonZeroI128, nonzero_check_max_for_128);
-    nonzero_check_max!(isize, core::num::NonZeroIsize, nonzero_check_max_for_isize);
-    nonzero_check_max!(u8, core::num::NonZeroU8, nonzero_check_max_for_u8);
-    nonzero_check_max!(u16, core::num::NonZeroU16, nonzero_check_max_for_u16);
-    nonzero_check_max!(u32, core::num::NonZeroU32, nonzero_check_max_for_u32);
-    nonzero_check_max!(u64, core::num::NonZeroU64, nonzero_check_max_for_u64);
-    nonzero_check_max!(u128, core::num::NonZeroU128, nonzero_check_max_for_u128);
-    nonzero_check_max!(usize, core::num::NonZeroUsize, nonzero_check_max_for_usize);
+    nonzero_check_max!(core::num::NonZeroI8, nonzero_check_max_for_i8);
+    nonzero_check_max!(core::num::NonZeroI16, nonzero_check_max_for_i16);
+    nonzero_check_max!(core::num::NonZeroI32, nonzero_check_max_for_i32);
+    nonzero_check_max!(core::num::NonZeroI64, nonzero_check_max_for_i64);
+    nonzero_check_max!(core::num::NonZeroI128, nonzero_check_max_for_i128);
+    nonzero_check_max!(core::num::NonZeroIsize, nonzero_check_max_for_isize);
+    nonzero_check_max!(core::num::NonZeroU8, nonzero_check_max_for_u8);
+    nonzero_check_max!(core::num::NonZeroU16, nonzero_check_max_for_u16);
+    nonzero_check_max!(core::num::NonZeroU32, nonzero_check_max_for_u32);
+    nonzero_check_max!(core::num::NonZeroU64, nonzero_check_max_for_u64);
+    nonzero_check_max!(core::num::NonZeroU128, nonzero_check_max_for_u128);
+    nonzero_check_max!(core::num::NonZeroUsize, nonzero_check_max_for_usize);
 }
 
 #[cfg(kani)]
 mod macro_nonzero_check_min {
     use super::*;
     macro_rules! nonzero_check_min {
-        ($t:ty, $nonzero_type:ty, $nonzero_check_min_for:ident) => {
+        ($nonzero_type:ty, $nonzero_check_min_for:ident) => {
             #[kani::proof]
             pub fn $nonzero_check_min_for() {
-                let int_x: $t = kani::any();
-                kani::assume(int_x != 0);
-                let int_y: $t = kani::any();
-                kani::assume(int_y != 0);
-                unsafe {
-                    let x = <$nonzero_type>::new_unchecked(int_x);
-                    let y = <$nonzero_type>::new_unchecked(int_y);
-                    let result = x.min(y);
-                    if x < y {
-                        assert!(result == x);
-                    } else {
-                        assert!(result == y);
-                    }
+                let x: $nonzero_type = kani::any();
+                let y: $nonzero_type = kani::any();
+                let result = x.min(y);
+                if x < y {
+                    assert!(result == x);
+                } else {
+                    assert!(result == y);
                 }
             }
         };
     }
 
-    // Use the macro to generate different versions of the function for multiple types
-    nonzero_check_min!(i8, core::num::NonZeroI8, nonzero_check_min_for_i8);
-    nonzero_check_min!(i16, core::num::NonZeroI16, nonzero_check_min_for_16);
-    nonzero_check_min!(i32, core::num::NonZeroI32, nonzero_check_min_for_32);
-    nonzero_check_min!(i64, core::num::NonZeroI64, nonzero_check_min_for_64);
-    nonzero_check_min!(i128, core::num::NonZeroI128, nonzero_check_min_for_128);
-    nonzero_check_min!(isize, core::num::NonZeroIsize, nonzero_check_min_for_isize);
-    nonzero_check_min!(u8, core::num::NonZeroU8, nonzero_check_min_for_u8);
-    nonzero_check_min!(u16, core::num::NonZeroU16, nonzero_check_min_for_u16);
-    nonzero_check_min!(u32, core::num::NonZeroU32, nonzero_check_min_for_u32);
-    nonzero_check_min!(u64, core::num::NonZeroU64, nonzero_check_min_for_u64);
-    nonzero_check_min!(u128, core::num::NonZeroU128, nonzero_check_min_for_u128);
-    nonzero_check_min!(usize, core::num::NonZeroUsize, nonzero_check_min_for_usize);
+    nonzero_check_min!(core::num::NonZeroI8, nonzero_check_min_for_i8);
+    nonzero_check_min!(core::num::NonZeroI16, nonzero_check_min_for_i16);
+    nonzero_check_min!(core::num::NonZeroI32, nonzero_check_min_for_i32);
+    nonzero_check_min!(core::num::NonZeroI64, nonzero_check_min_for_i64);
+    nonzero_check_min!(core::num::NonZeroI128, nonzero_check_min_for_i128);
+    nonzero_check_min!(core::num::NonZeroIsize, nonzero_check_min_for_isize);
+    nonzero_check_min!(core::num::NonZeroU8, nonzero_check_min_for_u8);
+    nonzero_check_min!(core::num::NonZeroU16, nonzero_check_min_for_u16);
+    nonzero_check_min!(core::num::NonZeroU32, nonzero_check_min_for_u32);
+    nonzero_check_min!(core::num::NonZeroU64, nonzero_check_min_for_u64);
+    nonzero_check_min!(core::num::NonZeroU128, nonzero_check_min_for_u128);
+    nonzero_check_min!(core::num::NonZeroUsize, nonzero_check_min_for_usize);
 }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -2273,23 +2273,20 @@ mod macro_nonzero_check_max {
         ($t:ty, $nonzero_type:ty, $nonzero_check_max_for:ident) => {
             #[kani::proof]
             pub fn $nonzero_check_max_for() {
-                let x: $t = kani::any();
-                kani::assume(x != 0);
-                let y: $t = kani::any();
-                kani::assume(y != 0);
-            
+                let int_x: $t = kani::any();
+                kani::assume(int_x != 0);
+                let int_y: $t = kani::any();
+                kani::assume(int_y != 0);   
                 unsafe {
-                    let x = <$nonzero_type>::new_unchecked(x);
-                    let y = <$nonzero_type>::new_unchecked(y);
-                }
-            
-                // Use the max function and check the result
-                let result = x.max(y);
-                if x > y {
-                    assert!(result == x);
-                } else {
-                    assert!(result == y);
-                }
+                    let x = <$nonzero_type>::new_unchecked(int_x);
+                    let y = <$nonzero_type>::new_unchecked(int_y);
+                    let result = x.max(y);
+                    if x > y {
+                        assert!(result == x);
+                    } else {
+                        assert!(result == y);
+                    }
+                }      
             }
         };
     }
@@ -2316,22 +2313,19 @@ mod macro_nonzero_check_min {
         ($t:ty, $nonzero_type:ty, $nonzero_check_min_for:ident) => {
             #[kani::proof]
             pub fn $nonzero_check_min_for() {
-                let x: $t = kani::any();
-                kani::assume(x != 0);
-                let y: $t = kani::any();
-                kani::assume(y != 0);
-            
+                let int_x: $t = kani::any();
+                kani::assume(int_x != 0);
+                let int_y: $t = kani::any();
+                kani::assume(int_y != 0);
                 unsafe {
-                    let x = <$nonzero_type>::new_unchecked(x);
-                    let y = <$nonzero_type>::new_unchecked(y);
-                }
-            
-                // Use the min function and check the result
-                let result = x.min(y);
-                if x < y {
-                    assert!(result == x);
-                } else {
-                    assert!(result == y);
+                    let x = <$nonzero_type>::new_unchecked(int_x);
+                    let y = <$nonzero_type>::new_unchecked(int_y);
+                    let result = x.min(y);
+                    if x < y {
+                        assert!(result == x);
+                    } else {
+                        assert!(result == y);
+                    }
                 }
             }
         };


### PR DESCRIPTION
Working on [#71](https://github.com/model-checking/verify-rust-std/issues/71) (Safety of NonZero)

We are looking for feedback on our proof for max and min.
This is the initial logic; we will add a macro to extrapolate for data types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.