### PR TITLE
NonZero (rotate_left, rotate_right, max, min, clamp, count_ones, cmp) Proofs

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -2264,11 +2264,201 @@ mod verify {
     nonzero_check!(u64, core::num::NonZeroU64, nonzero_check_new_unchecked_for_u64);
     nonzero_check!(u128, core::num::NonZeroU128, nonzero_check_new_unchecked_for_u128);
     nonzero_check!(usize, core::num::NonZeroUsize, nonzero_check_new_unchecked_for_usize);
-}
 
-#[cfg(kani)]
-mod macro_nonzero_check_rotate_left_and_right {
-    use super::*;
+    macro_rules! nonzero_check_cmp {
+        ($nonzero_type:ty, $nonzero_check_cmp_for:ident) => {
+            #[kani::proof]
+            pub fn $nonzero_check_cmp_for() {
+                let x: $nonzero_type = kani::any();
+                let y: $nonzero_type = kani::any();
+                if x < y {
+                    assert!(x.cmp(&y) == core::cmp::Ordering::Less);
+                } else if x > y {
+                    assert!(x.cmp(&y) == core::cmp::Ordering::Greater);
+                } else {
+                    assert!(x.cmp(&y) == core::cmp::Ordering::Equal);
+                }
+            }
+        };
+    }
+
+    // Use the macro to generate different versions of the function for multiple types
+    nonzero_check_cmp!(core::num::NonZeroI8, nonzero_check_cmp_for_i8);
+    nonzero_check_cmp!(core::num::NonZeroI16, nonzero_check_cmp_for_i16);
+    nonzero_check_cmp!(core::num::NonZeroI32, nonzero_check_cmp_for_i32);
+    nonzero_check_cmp!(core::num::NonZeroI64, nonzero_check_cmp_for_i64);
+    nonzero_check_cmp!(core::num::NonZeroI128, nonzero_check_cmp_for_i128);
+    nonzero_check_cmp!(core::num::NonZeroIsize, nonzero_check_cmp_for_isize);
+    nonzero_check_cmp!(core::num::NonZeroU8, nonzero_check_cmp_for_u8);
+    nonzero_check_cmp!(core::num::NonZeroU16, nonzero_check_cmp_for_u16);
+    nonzero_check_cmp!(core::num::NonZeroU32, nonzero_check_cmp_for_u32);
+    nonzero_check_cmp!(core::num::NonZeroU64, nonzero_check_cmp_for_u64);
+    nonzero_check_cmp!(core::num::NonZeroU128, nonzero_check_cmp_for_u128);
+    nonzero_check_cmp!(core::num::NonZeroUsize, nonzero_check_cmp_for_usize);
+    
+    
+    macro_rules! nonzero_check_max {
+        ($nonzero_type:ty, $nonzero_check_max_for:ident) => {
+            #[kani::proof]
+            pub fn $nonzero_check_max_for() {
+                let x: $nonzero_type = kani::any();
+                let y: $nonzero_type = kani::any();
+                let result = x.max(y);
+                if x > y {
+                    assert!(result == x);
+                } else {
+                    assert!(result == y);
+                }
+            }
+        };
+    }
+
+    nonzero_check_max!(core::num::NonZeroI8, nonzero_check_max_for_i8);
+    nonzero_check_max!(core::num::NonZeroI16, nonzero_check_max_for_i16);
+    nonzero_check_max!(core::num::NonZeroI32, nonzero_check_max_for_i32);
+    nonzero_check_max!(core::num::NonZeroI64, nonzero_check_max_for_i64);
+    nonzero_check_max!(core::num::NonZeroI128, nonzero_check_max_for_i128);
+    nonzero_check_max!(core::num::NonZeroIsize, nonzero_check_max_for_isize);
+    nonzero_check_max!(core::num::NonZeroU8, nonzero_check_max_for_u8);
+    nonzero_check_max!(core::num::NonZeroU16, nonzero_check_max_for_u16);
+    nonzero_check_max!(core::num::NonZeroU32, nonzero_check_max_for_u32);
+    nonzero_check_max!(core::num::NonZeroU64, nonzero_check_max_for_u64);
+    nonzero_check_max!(core::num::NonZeroU128, nonzero_check_max_for_u128);
+    nonzero_check_max!(core::num::NonZeroUsize, nonzero_check_max_for_usize);
+
+    
+    macro_rules! nonzero_check_min {
+        ($nonzero_type:ty, $nonzero_check_min_for:ident) => {
+            #[kani::proof]
+            pub fn $nonzero_check_min_for() {
+                let x: $nonzero_type = kani::any();
+                let y: $nonzero_type = kani::any();
+                let result = x.min(y);
+                if x < y {
+                    assert!(result == x);
+                } else {
+                    assert!(result == y);
+                }
+            }
+        };
+    }
+
+    nonzero_check_min!(core::num::NonZeroI8, nonzero_check_min_for_i8);
+    nonzero_check_min!(core::num::NonZeroI16, nonzero_check_min_for_i16);
+    nonzero_check_min!(core::num::NonZeroI32, nonzero_check_min_for_i32);
+    nonzero_check_min!(core::num::NonZeroI64, nonzero_check_min_for_i64);
+    nonzero_check_min!(core::num::NonZeroI128, nonzero_check_min_for_i128);
+    nonzero_check_min!(core::num::NonZeroIsize, nonzero_check_min_for_isize);
+    nonzero_check_min!(core::num::NonZeroU8, nonzero_check_min_for_u8);
+    nonzero_check_min!(core::num::NonZeroU16, nonzero_check_min_for_u16);
+    nonzero_check_min!(core::num::NonZeroU32, nonzero_check_min_for_u32);
+    nonzero_check_min!(core::num::NonZeroU64, nonzero_check_min_for_u64);
+    nonzero_check_min!(core::num::NonZeroU128, nonzero_check_min_for_u128);
+    nonzero_check_min!(core::num::NonZeroUsize, nonzero_check_min_for_usize);
+
+    
+    macro_rules! nonzero_check_clamp {
+        ($nonzero_type:ty, $nonzero_check_clamp_for:ident) => {
+            #[kani::proof]
+            pub fn $nonzero_check_clamp_for() {
+                let x: $nonzero_type = kani::any();
+                let min: $nonzero_type = kani::any();
+                let max: $nonzero_type = kani::any();
+                // Ensure min <= max, so the function should no panic
+                kani::assume(min <= max);
+                // Use the clamp function and check the result
+                let result = x.clamp(min, max);
+                if x < min {
+                    assert!(result == min);
+                } else if x > max {
+                    assert!(result == max);
+                } else {
+                    assert!(result == x);
+                }
+            }
+        };
+    }
+
+    // Use the macro to generate different versions of the function for multiple types
+    nonzero_check_clamp!(core::num::NonZeroI8, nonzero_check_clamp_for_i8);
+    nonzero_check_clamp!(core::num::NonZeroI16, nonzero_check_clamp_for_16);
+    nonzero_check_clamp!(core::num::NonZeroI32, nonzero_check_clamp_for_32);
+    nonzero_check_clamp!(core::num::NonZeroI64, nonzero_check_clamp_for_64);
+    nonzero_check_clamp!(core::num::NonZeroI128, nonzero_check_clamp_for_128);
+    nonzero_check_clamp!(core::num::NonZeroIsize, nonzero_check_clamp_for_isize);
+    nonzero_check_clamp!(core::num::NonZeroU8, nonzero_check_clamp_for_u8);
+    nonzero_check_clamp!(core::num::NonZeroU16, nonzero_check_clamp_for_u16);
+    nonzero_check_clamp!(core::num::NonZeroU32, nonzero_check_clamp_for_u32);
+    nonzero_check_clamp!(core::num::NonZeroU64, nonzero_check_clamp_for_u64);
+    nonzero_check_clamp!(core::num::NonZeroU128, nonzero_check_clamp_for_u128);
+    nonzero_check_clamp!(core::num::NonZeroUsize, nonzero_check_clamp_for_usize);
+
+    
+    macro_rules! nonzero_check_clamp_panic {
+        ($nonzero_type:ty, $nonzero_check_clamp_for:ident) => {
+            #[kani::proof]
+            #[kani::should_panic]
+            pub fn $nonzero_check_clamp_for() {
+                let x: $nonzero_type = kani::any();
+                let min: $nonzero_type = kani::any();
+                let max: $nonzero_type = kani::any();
+                // Ensure min > max, so the function should panic
+                kani::assume(min > max);
+                // Use the clamp function and check the result
+                let result = x.clamp(min, max);
+                if x < min {
+                    assert!(result == min);
+                } else if x > max {
+                    assert!(result == max);
+                } else {
+                    assert!(result == x);
+                }
+            }
+        };
+    }
+
+    // Use the macro to generate different versions of the function for multiple types
+    nonzero_check_clamp_panic!(core::num::NonZeroI8, nonzero_check_clamp_panic_for_i8);
+    nonzero_check_clamp_panic!(core::num::NonZeroI16, nonzero_check_clamp_panic_for_16);
+    nonzero_check_clamp_panic!(core::num::NonZeroI32, nonzero_check_clamp_panic_for_32);
+    nonzero_check_clamp_panic!(core::num::NonZeroI64, nonzero_check_clamp_panic_for_64);
+    nonzero_check_clamp_panic!(core::num::NonZeroI128, nonzero_check_clamp_panic_for_128);
+    nonzero_check_clamp_panic!(core::num::NonZeroIsize, nonzero_check_clamp_panic_for_isize);
+    nonzero_check_clamp_panic!(core::num::NonZeroU8, nonzero_check_clamp_panic_for_u8);
+    nonzero_check_clamp_panic!(core::num::NonZeroU16, nonzero_check_clamp_panic_for_u16);
+    nonzero_check_clamp_panic!(core::num::NonZeroU32, nonzero_check_clamp_panic_for_u32);
+    nonzero_check_clamp_panic!(core::num::NonZeroU64, nonzero_check_clamp_panic_for_u64);
+    nonzero_check_clamp_panic!(core::num::NonZeroU128, nonzero_check_clamp_panic_for_u128);
+    nonzero_check_clamp_panic!(core::num::NonZeroUsize, nonzero_check_clamp_panic_for_usize);
+
+    
+    macro_rules! nonzero_check_count_ones {
+        ($nonzero_type:ty, $nonzero_check_count_ones_for:ident) => {
+            #[kani::proof]
+            pub fn $nonzero_check_count_ones_for() {
+                let x: $nonzero_type = kani::any();
+                let result = x.count_ones();
+                // Since x is non-zero, count_ones should never return 0
+                assert!(result.get() > 0);
+            }
+        };
+    }
+
+    // Use the macro to generate different versions of the function for multiple types
+    nonzero_check_count_ones!(core::num::NonZeroI8, nonzero_check_count_ones_for_i8);
+    nonzero_check_count_ones!(core::num::NonZeroI16, nonzero_check_count_ones_for_i16);
+    nonzero_check_count_ones!(core::num::NonZeroI32, nonzero_check_count_ones_for_i32);
+    nonzero_check_count_ones!(core::num::NonZeroI64, nonzero_check_count_ones_for_i64);
+    nonzero_check_count_ones!(core::num::NonZeroI128, nonzero_check_count_ones_for_i128);
+    nonzero_check_count_ones!(core::num::NonZeroIsize, nonzero_check_count_ones_for_isize);
+    nonzero_check_count_ones!(core::num::NonZeroU8, nonzero_check_count_ones_for_u8);
+    nonzero_check_count_ones!(core::num::NonZeroU16, nonzero_check_count_ones_for_u16);
+    nonzero_check_count_ones!(core::num::NonZeroU32, nonzero_check_count_ones_for_u32);
+    nonzero_check_count_ones!(core::num::NonZeroU64, nonzero_check_count_ones_for_u64);
+    nonzero_check_count_ones!(core::num::NonZeroU128, nonzero_check_count_ones_for_u128);
+    nonzero_check_count_ones!(core::num::NonZeroUsize, nonzero_check_count_ones_for_usize);
+
+    
     macro_rules! nonzero_check_rotate_left_and_right {
         ($nonzero_type:ty, $nonzero_check_rotate_for:ident) => {
             #[kani::proof]

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -2270,32 +2270,28 @@ mod verify {
 mod macro_nonzero_check_rotate_left_and_right {
     use super::*;
     macro_rules! nonzero_check_rotate_left_and_right {
-        ($t:ty, $nonzero_type:ty, $nonzero_check_rotate_right_for:ident) => {
+        ($nonzero_type:ty, $nonzero_check_rotate_for:ident) => {
             #[kani::proof]
-            pub fn $nonzero_check_rotate_right_for() {
-                let int_x: $t = kani::any();
+            pub fn $nonzero_check_rotate_for() {
+                let x: $nonzero_type = kani::any();
                 let n: u32 = kani::any();
-                kani::assume(int_x != 0);
-                unsafe {
-                    let x = <$nonzero_type>::new_unchecked(int_x);
-                    let result = x.rotate_left(n).rotate_right(n);
-                    assert!(result == x);
-                } 
+                let result = x.rotate_left(n).rotate_right(n);
+                assert!(result == x);
             }
         };
     }
 
-    // Use the macro to generate different versions of the function for multiple types
-    nonzero_check_rotate_left_and_right!(i8, core::num::NonZeroI8, nonzero_check_rotate_for_i8);
-    nonzero_check_rotate_left_and_right!(i16, core::num::NonZeroI16, nonzero_check_rotate_for_16);
-    nonzero_check_rotate_left_and_right!(i32, core::num::NonZeroI32, nonzero_check_rotate_for_32);
-    nonzero_check_rotate_left_and_right!(i64, core::num::NonZeroI64, nonzero_check_rotate_for_64);
-    nonzero_check_rotate_left_and_right!(i128, core::num::NonZeroI128, nonzero_check_rotate_for_128);
-    nonzero_check_rotate_left_and_right!(isize, core::num::NonZeroIsize, nonzero_check_rotate_for_isize);
-    nonzero_check_rotate_left_and_right!(u8, core::num::NonZeroU8, nonzero_check_rotate_for_u8);
-    nonzero_check_rotate_left_and_right!(u16, core::num::NonZeroU16, nonzero_check_rotate_for_u16);
-    nonzero_check_rotate_left_and_right!(u32, core::num::NonZeroU32, nonzero_check_rotate_for_u32);
-    nonzero_check_rotate_left_and_right!(u64, core::num::NonZeroU64, nonzero_check_rotate_for_u64);
-    nonzero_check_rotate_left_and_right!(u128, core::num::NonZeroU128, nonzero_check_rotate_for_u128);
-    nonzero_check_rotate_left_and_right!(usize, core::num::NonZeroUsize, nonzero_check_rotate_for_usize);
+    // 为多种类型生成不同的函数版本
+    nonzero_check_rotate_left_and_right!(core::num::NonZeroI8, nonzero_check_rotate_for_i8);
+    nonzero_check_rotate_left_and_right!(core::num::NonZeroI16, nonzero_check_rotate_for_i16);
+    nonzero_check_rotate_left_and_right!(core::num::NonZeroI32, nonzero_check_rotate_for_i32);
+    nonzero_check_rotate_left_and_right!(core::num::NonZeroI64, nonzero_check_rotate_for_i64);
+    nonzero_check_rotate_left_and_right!(core::num::NonZeroI128, nonzero_check_rotate_for_i128);
+    nonzero_check_rotate_left_and_right!(core::num::NonZeroIsize, nonzero_check_rotate_for_isize);
+    nonzero_check_rotate_left_and_right!(core::num::NonZeroU8, nonzero_check_rotate_for_u8);
+    nonzero_check_rotate_left_and_right!(core::num::NonZeroU16, nonzero_check_rotate_for_u16);
+    nonzero_check_rotate_left_and_right!(core::num::NonZeroU32, nonzero_check_rotate_for_u32);
+    nonzero_check_rotate_left_and_right!(core::num::NonZeroU64, nonzero_check_rotate_for_u64);
+    nonzero_check_rotate_left_and_right!(core::num::NonZeroU128, nonzero_check_rotate_for_u128);
+    nonzero_check_rotate_left_and_right!(core::num::NonZeroUsize, nonzero_check_rotate_for_usize);
 }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -2281,7 +2281,7 @@ mod macro_nonzero_check_rotate_left_and_right {
         };
     }
 
-    // 为多种类型生成不同的函数版本
+    // Use the macro to generate different versions of the function for multiple types
     nonzero_check_rotate_left_and_right!(core::num::NonZeroI8, nonzero_check_rotate_for_i8);
     nonzero_check_rotate_left_and_right!(core::num::NonZeroI16, nonzero_check_rotate_for_i16);
     nonzero_check_rotate_left_and_right!(core::num::NonZeroI32, nonzero_check_rotate_for_i32);

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -2276,7 +2276,6 @@ mod macro_nonzero_check_rotate_left_and_right {
                 let int_x: $t = kani::any();
                 let n: u32 = kani::any();
                 kani::assume(int_x != 0);
-                kani::assume(n < (core::mem::size_of::<$t>() as u32 * 8));
                 unsafe {
                     let x = <$nonzero_type>::new_unchecked(int_x);
                     let result = x.rotate_left(n).rotate_right(n);

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -2267,90 +2267,36 @@ mod verify {
 }
 
 #[cfg(kani)]
-mod macro_nonzero_check_rotate_left {
+mod macro_nonzero_check_rotate_left_and_right {
     use super::*;
-    macro_rules! nonzero_check_rotate_left {
-        ($t:ty, $nonzero_type:ty, $nonzero_check_rotate_left_for:ident) => {
-            #[kani::proof]
-            pub fn $nonzero_check_rotate_left_for() {
-                let int_x: $t = kani::any();
-                let n: u32 = kani::any();
-                kani::assume(int_x != 0); // x must be non-zero
-
-                // Ensure that n is within a valid range for rotating
-                // kani::assume(n < (std::mem::size_of::<$t>() as u32 * 8));
-                // need to use core::mem instead of std::mem
-                kani::assume(n < (core::mem::size_of::<$t>() as u32 * 8));
-                kani::assume(n >= 0);
-                
-                unsafe {
-                    let x = <$nonzero_type>::new_unchecked(int_x);
-                    // Perform rotate_left
-                    let result = x.rotate_left(n);
-                    
-                    // Ensure the result is still non-zero
-                    assert!(result.get() != 0);
-                }
-            }
-        };
-    }
-
-    // Use the macro to generate different versions of the function for multiple types
-    nonzero_check_rotate_left!(i8, core::num::NonZeroI8, nonzero_check_rotate_left_for_i8);
-    nonzero_check_rotate_left!(i16, core::num::NonZeroI16, nonzero_check_rotate_left_for_16);
-    nonzero_check_rotate_left!(i32, core::num::NonZeroI32, nonzero_check_rotate_left_for_32);
-    nonzero_check_rotate_left!(i64, core::num::NonZeroI64, nonzero_check_rotate_left_for_64);
-    nonzero_check_rotate_left!(i128, core::num::NonZeroI128, nonzero_check_rotate_left_for_128);
-    nonzero_check_rotate_left!(isize, core::num::NonZeroIsize, nonzero_check_rotate_left_for_isize);
-    nonzero_check_rotate_left!(u8, core::num::NonZeroU8, nonzero_check_rotate_left_for_u8);
-    nonzero_check_rotate_left!(u16, core::num::NonZeroU16, nonzero_check_rotate_left_for_u16);
-    nonzero_check_rotate_left!(u32, core::num::NonZeroU32, nonzero_check_rotate_left_for_u32);
-    nonzero_check_rotate_left!(u64, core::num::NonZeroU64, nonzero_check_rotate_left_for_u64);
-    nonzero_check_rotate_left!(u128, core::num::NonZeroU128, nonzero_check_rotate_left_for_u128);
-    nonzero_check_rotate_left!(usize, core::num::NonZeroUsize, nonzero_check_rotate_left_for_usize);
-}
-
-#[cfg(kani)]
-mod macro_nonzero_check_rotate_right {
-    use super::*;
-    macro_rules! nonzero_check_rotate_right {
+    macro_rules! nonzero_check_rotate_left_and_right {
         ($t:ty, $nonzero_type:ty, $nonzero_check_rotate_right_for:ident) => {
             #[kani::proof]
             pub fn $nonzero_check_rotate_right_for() {
                 let int_x: $t = kani::any();
                 let n: u32 = kani::any();
-                kani::assume(int_x != 0); // x must be non-zero
-
-                // Ensure that n is within a valid range for rotating
+                kani::assume(int_x != 0);
                 kani::assume(n < (core::mem::size_of::<$t>() as u32 * 8));
-                kani::assume(n >= 0);
-                
                 unsafe {
                     let x = <$nonzero_type>::new_unchecked(int_x);
-
-                    // Perform rotate_right
-                    let result = x.rotate_right(n);
-                    
-                    // Ensure the result is still non-zero
-                    assert!(result.get() != 0);
-                }
-
-                
+                    let result = x.rotate_left(n).rotate_right(n);
+                    assert!(result == x);
+                } 
             }
         };
     }
 
     // Use the macro to generate different versions of the function for multiple types
-    nonzero_check_rotate_right!(i8, core::num::NonZeroI8, nonzero_check_rotate_right_for_i8);
-    nonzero_check_rotate_right!(i16, core::num::NonZeroI16, nonzero_check_rotate_right_for_16);
-    nonzero_check_rotate_right!(i32, core::num::NonZeroI32, nonzero_check_rotate_right_for_32);
-    nonzero_check_rotate_right!(i64, core::num::NonZeroI64, nonzero_check_rotate_right_for_64);
-    nonzero_check_rotate_right!(i128, core::num::NonZeroI128, nonzero_check_rotate_right_for_128);
-    nonzero_check_rotate_right!(isize, core::num::NonZeroIsize, nonzero_check_rotate_right_for_isize);
-    nonzero_check_rotate_right!(u8, core::num::NonZeroU8, nonzero_check_rotate_right_for_u8);
-    nonzero_check_rotate_right!(u16, core::num::NonZeroU16, nonzero_check_rotate_right_for_u16);
-    nonzero_check_rotate_right!(u32, core::num::NonZeroU32, nonzero_check_rotate_right_for_u32);
-    nonzero_check_rotate_right!(u64, core::num::NonZeroU64, nonzero_check_rotate_right_for_u64);
-    nonzero_check_rotate_right!(u128, core::num::NonZeroU128, nonzero_check_rotate_right_for_u128);
-    nonzero_check_rotate_right!(usize, core::num::NonZeroUsize, nonzero_check_rotate_right_for_usize);
+    nonzero_check_rotate_left_and_right!(i8, core::num::NonZeroI8, nonzero_check_rotate_for_i8);
+    nonzero_check_rotate_left_and_right!(i16, core::num::NonZeroI16, nonzero_check_rotate_for_16);
+    nonzero_check_rotate_left_and_right!(i32, core::num::NonZeroI32, nonzero_check_rotate_for_32);
+    nonzero_check_rotate_left_and_right!(i64, core::num::NonZeroI64, nonzero_check_rotate_for_64);
+    nonzero_check_rotate_left_and_right!(i128, core::num::NonZeroI128, nonzero_check_rotate_for_128);
+    nonzero_check_rotate_left_and_right!(isize, core::num::NonZeroIsize, nonzero_check_rotate_for_isize);
+    nonzero_check_rotate_left_and_right!(u8, core::num::NonZeroU8, nonzero_check_rotate_for_u8);
+    nonzero_check_rotate_left_and_right!(u16, core::num::NonZeroU16, nonzero_check_rotate_for_u16);
+    nonzero_check_rotate_left_and_right!(u32, core::num::NonZeroU32, nonzero_check_rotate_for_u32);
+    nonzero_check_rotate_left_and_right!(u64, core::num::NonZeroU64, nonzero_check_rotate_for_u64);
+    nonzero_check_rotate_left_and_right!(u128, core::num::NonZeroU128, nonzero_check_rotate_for_u128);
+    nonzero_check_rotate_left_and_right!(usize, core::num::NonZeroUsize, nonzero_check_rotate_for_usize);
 }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -2273,9 +2273,9 @@ mod macro_nonzero_check_rotate_left {
         ($t:ty, $nonzero_type:ty, $nonzero_check_rotate_left_for:ident) => {
             #[kani::proof]
             pub fn $nonzero_check_rotate_left_for() {
-                let x: $t = kani::any();
+                let int_x: $t = kani::any();
                 let n: u32 = kani::any();
-                kani::assume(x != 0); // x must be non-zero
+                kani::assume(int_x != 0); // x must be non-zero
 
                 // Ensure that n is within a valid range for rotating
                 // kani::assume(n < (std::mem::size_of::<$t>() as u32 * 8));
@@ -2284,14 +2284,13 @@ mod macro_nonzero_check_rotate_left {
                 kani::assume(n >= 0);
                 
                 unsafe {
-                    let x = <$nonzero_type>::new_unchecked(x);
+                    let x = <$nonzero_type>::new_unchecked(int_x);
+                    // Perform rotate_left
+                    let result = x.rotate_left(n);
+                    
+                    // Ensure the result is still non-zero
+                    assert!(result.get() != 0);
                 }
-
-                // Perform rotate_left
-                let result = x.rotate_left(n);
-                
-                // Ensure the result is still non-zero
-                assert!(result != 0);
             }
         };
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -2265,3 +2265,91 @@ mod verify {
     nonzero_check!(u128, core::num::NonZeroU128, nonzero_check_new_unchecked_for_u128);
     nonzero_check!(usize, core::num::NonZeroUsize, nonzero_check_new_unchecked_for_usize);
 }
+
+#[cfg(kani)]
+mod macro_nonzero_check_rotate_left {
+    use super::*;
+    macro_rules! nonzero_check_rotate_left {
+        ($t:ty, $nonzero_type:ty, $nonzero_check_rotate_left_for:ident) => {
+            #[kani::proof]
+            pub fn $nonzero_check_rotate_left_for() {
+                let x: $t = kani::any();
+                let n: u32 = kani::any();
+                kani::assume(x != 0); // x must be non-zero
+
+                // Ensure that n is within a valid range for rotating
+                // kani::assume(n < (std::mem::size_of::<$t>() as u32 * 8));
+                // need to use core::mem instead of std::mem
+                kani::assume(n < (core::mem::size_of::<$t>() as u32 * 8));
+                kani::assume(n >= 0);
+                
+                unsafe {
+                    let x = <$nonzero_type>::new_unchecked(x);
+                }
+
+                // Perform rotate_left
+                let result = x.rotate_left(n);
+                
+                // Ensure the result is still non-zero
+                assert!(result != 0);
+            }
+        };
+    }
+
+    // Use the macro to generate different versions of the function for multiple types
+    nonzero_check_rotate_left!(i8, core::num::NonZeroI8, nonzero_check_rotate_left_for_i8);
+    nonzero_check_rotate_left!(i16, core::num::NonZeroI16, nonzero_check_rotate_left_for_16);
+    nonzero_check_rotate_left!(i32, core::num::NonZeroI32, nonzero_check_rotate_left_for_32);
+    nonzero_check_rotate_left!(i64, core::num::NonZeroI64, nonzero_check_rotate_left_for_64);
+    nonzero_check_rotate_left!(i128, core::num::NonZeroI128, nonzero_check_rotate_left_for_128);
+    nonzero_check_rotate_left!(isize, core::num::NonZeroIsize, nonzero_check_rotate_left_for_isize);
+    nonzero_check_rotate_left!(u8, core::num::NonZeroU8, nonzero_check_rotate_left_for_u8);
+    nonzero_check_rotate_left!(u16, core::num::NonZeroU16, nonzero_check_rotate_left_for_u16);
+    nonzero_check_rotate_left!(u32, core::num::NonZeroU32, nonzero_check_rotate_left_for_u32);
+    nonzero_check_rotate_left!(u64, core::num::NonZeroU64, nonzero_check_rotate_left_for_u64);
+    nonzero_check_rotate_left!(u128, core::num::NonZeroU128, nonzero_check_rotate_left_for_u128);
+    nonzero_check_rotate_left!(usize, core::num::NonZeroUsize, nonzero_check_rotate_left_for_usize);
+}
+
+#[cfg(kani)]
+mod macro_nonzero_check_rotate_right {
+    use super::*;
+    macro_rules! nonzero_check_rotate_right {
+        ($t:ty, $nonzero_type:ty, $nonzero_check_rotate_right_for:ident) => {
+            #[kani::proof]
+            pub fn $nonzero_check_rotate_right_for() {
+                let x: $t = kani::any();
+                let n: u32 = kani::any();
+                kani::assume(x != 0); // x must be non-zero
+
+                // Ensure that n is within a valid range for rotating
+                kani::assume(n < (core::mem::size_of::<$t>() as u32 * 8));
+                kani::assume(n >= 0);
+                
+                unsafe {
+                    let x = <$nonzero_type>::new_unchecked(x);
+                }
+
+                // Perform rotate_right
+                let result = x.rotate_right(n);
+                
+                // Ensure the result is still non-zero
+                assert!(result != 0);
+            }
+        };
+    }
+
+    // Use the macro to generate different versions of the function for multiple types
+    nonzero_check_rotate_right!(i8, core::num::NonZeroI8, nonzero_check_rotate_right_for_i8);
+    nonzero_check_rotate_right!(i16, core::num::NonZeroI16, nonzero_check_rotate_right_for_16);
+    nonzero_check_rotate_right!(i32, core::num::NonZeroI32, nonzero_check_rotate_right_for_32);
+    nonzero_check_rotate_right!(i64, core::num::NonZeroI64, nonzero_check_rotate_right_for_64);
+    nonzero_check_rotate_right!(i128, core::num::NonZeroI128, nonzero_check_rotate_right_for_128);
+    nonzero_check_rotate_right!(isize, core::num::NonZeroIsize, nonzero_check_rotate_right_for_isize);
+    nonzero_check_rotate_right!(u8, core::num::NonZeroU8, nonzero_check_rotate_right_for_u8);
+    nonzero_check_rotate_right!(u16, core::num::NonZeroU16, nonzero_check_rotate_right_for_u16);
+    nonzero_check_rotate_right!(u32, core::num::NonZeroU32, nonzero_check_rotate_right_for_u32);
+    nonzero_check_rotate_right!(u64, core::num::NonZeroU64, nonzero_check_rotate_right_for_u64);
+    nonzero_check_rotate_right!(u128, core::num::NonZeroU128, nonzero_check_rotate_right_for_u128);
+    nonzero_check_rotate_right!(usize, core::num::NonZeroUsize, nonzero_check_rotate_right_for_usize);
+}

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -2318,23 +2318,25 @@ mod macro_nonzero_check_rotate_right {
         ($t:ty, $nonzero_type:ty, $nonzero_check_rotate_right_for:ident) => {
             #[kani::proof]
             pub fn $nonzero_check_rotate_right_for() {
-                let x: $t = kani::any();
+                let int_x: $t = kani::any();
                 let n: u32 = kani::any();
-                kani::assume(x != 0); // x must be non-zero
+                kani::assume(int_x != 0); // x must be non-zero
 
                 // Ensure that n is within a valid range for rotating
                 kani::assume(n < (core::mem::size_of::<$t>() as u32 * 8));
                 kani::assume(n >= 0);
                 
                 unsafe {
-                    let x = <$nonzero_type>::new_unchecked(x);
+                    let x = <$nonzero_type>::new_unchecked(int_x);
+
+                    // Perform rotate_right
+                    let result = x.rotate_right(n);
+                    
+                    // Ensure the result is still non-zero
+                    assert!(result.get() != 0);
                 }
 
-                // Perform rotate_right
-                let result = x.rotate_right(n);
                 
-                // Ensure the result is still non-zero
-                assert!(result != 0);
             }
         };
     }


### PR DESCRIPTION
Working on [#71](https://github.com/model-checking/verify-rust-std/issues/71) (Safety of NonZero)

We are looking for feedback on our proof for rotate_left & rotate_right.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.