### PR TITLE
Enable harnesses that were blocked by Kani's spurious CEX

### DIFF
--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -3604,18 +3604,24 @@ mod verify {
                 }
 
                 check_unsafe_contracts!(check_next_back_unchecked, $ty, next_back_unchecked());
-                //check_unsafe_contracts!(check_post_inc_start, $ty, post_inc_start(kani::any()));
-                //check_unsafe_contracts!(check_pre_dec_end, $ty, pre_dec_end(kani::any()));
+                check_unsafe_contracts!(check_post_inc_start, $ty, post_inc_start(kani::any()));
+                check_unsafe_contracts!(check_pre_dec_end, $ty, pre_dec_end(kani::any()));
 
                 // FIXME: The functions that are commented out are currently failing verification.
                 // Debugging the issue is currently blocked by:
                 // https://github.com/model-checking/kani/issues/3670
                 //
                 // Public functions that call safe abstraction `make_slice`.
-                // check_safe_abstraction!(check_as_slice, $ty, as_slice);
-                // check_safe_abstraction!(check_as_ref, $ty, as_ref);
+                check_safe_abstraction!(check_as_slice, $ty, |iter: &mut Iter<'_, $ty>| {
+                    iter.as_slice();
+                });
+                check_safe_abstraction!(check_as_ref, $ty, |iter: &mut Iter<'_, $ty>| {
+                    iter.as_ref();
+                });
 
-                // check_safe_abstraction!(check_advance_back_by, $ty, advance_back_by, kani::any());
+                check_safe_abstraction!(check_advance_back_by, $ty, |iter: &mut Iter<'_, $ty>| {
+                    iter.advance_back_by(kani::any());
+                });
 
                 check_safe_abstraction!(check_is_empty, $ty, |iter: &mut Iter<'_, $ty>| {
                     let _ = iter.is_empty();
@@ -3626,12 +3632,12 @@ mod verify {
                 check_safe_abstraction!(check_size_hint, $ty, |iter: &mut Iter<'_, $ty>| {
                     let _ = iter.size_hint();
                 });
-                //check_safe_abstraction!(check_nth, $ty, |iter: &mut Iter<'_, $ty>| { let _ = iter.nth(kani::any()); });
-                //check_safe_abstraction!(check_advance_by, $ty, |iter: &mut Iter<'_, $ty>| { let _ = iter.advance_by(kani::any()); });
+                check_safe_abstraction!(check_nth, $ty, |iter: &mut Iter<'_, $ty>| { let _ = iter.nth(kani::any()); });
+                check_safe_abstraction!(check_advance_by, $ty, |iter: &mut Iter<'_, $ty>| { let _ = iter.advance_by(kani::any()); });
                 check_safe_abstraction!(check_next_back, $ty, |iter: &mut Iter<'_, $ty>| {
                     let _ = iter.next_back();
                 });
-                //check_safe_abstraction!(check_nth_back, $ty, |iter: &mut Iter<'_, $ty>| { let _ = iter.nth_back(kani::any()); });
+                check_safe_abstraction!(check_nth_back, $ty, |iter: &mut Iter<'_, $ty>| { let _ = iter.nth_back(kani::any()); });
                 check_safe_abstraction!(check_next, $ty, |iter: &mut Iter<'_, $ty>| {
                     let _ = iter.next();
                 });

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -2000,10 +2000,6 @@ pub mod verify {
         }
     }
 
-    /* This harness check `small_slice_eq` with dangling pointer to slice
-       with zero size. Kani finds safety issue of `small_slice_eq` in this
-       harness and hence the proof will fail.
-
     #[cfg(all(kani, target_arch = "x86_64"))] // only called on x86
     #[kani::proof]
     #[kani::unwind(4)]
@@ -2022,5 +2018,4 @@ pub mod verify {
             true
         );
     }
-    */
 }


### PR DESCRIPTION
In #148 and #122, we had to comment out a few harnesses due to the issue https://github.com/model-checking/kani/issues/3670. But now that the fix has been pushed, we can enable them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
