### PR TITLE
Prepare repo for enabling merge queue

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -3,6 +3,7 @@
 name: Build Book
 on:
   workflow_dispatch:
+  merge_group:
   pull_request:
     branches: [ main ]
   push:

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -2,6 +2,7 @@ name: Kani
 
 on:
   workflow_dispatch:
+  merge_group:
   pull_request:
     branches: [ main ]
   push:

--- a/.github/workflows/pr_approval.yml
+++ b/.github/workflows/pr_approval.yml
@@ -1,12 +1,18 @@
+# This workflow checks that the PR has been approved by 2+  members of the committee listed in `pull_requests.toml`.
+#
+# Run this pull request when a request review is submitted / dismissed.
+# Note that an approval can be dismissed, and this can affect the job status.
+# We currently trust that contributors won't make significant changes to their PRs after approval, so we accept
+# changes after approval.
+#
+# We still need to run this in the case of a merge group, since it is a required step. In that case, the workflow
+# is a NOP.
 name: Check PR Approvals
-
-# For now, the workflow gets triggered only when a review is submitted
-# This technically means, a PR with zero approvals can be merged by the rules of this workflow alone
-# To protect against that scenario, we can turn on number of approvals required to 2 in the github settings
-# of the repository
 on:
+  merge_group:
+  pull_request:
   pull_request_review:
-    types: [submitted]
+    types: [submitted, dismissed]
 
 jobs:
   check-approvals:
@@ -14,12 +20,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        if: ${{ github.event_name != 'merge_group' }}
 
       - name: Install TOML parser
         run: npm install @iarna/toml
+        if: ${{ github.event_name != 'merge_group' }}
 
       - name: Check PR Relevance and Approvals
         uses: actions/github-script@v6
+        if: ${{ github.event_name != 'merge_group' }}
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/pr_approval.yml
+++ b/.github/workflows/pr_approval.yml
@@ -1,6 +1,6 @@
-# This workflow checks that the PR has been approved by 2+  members of the committee listed in `pull_requests.toml`.
+# This workflow checks that the PR has been approved by 2+ members of the committee listed in `pull_requests.toml`.
 #
-# Run this pull request when a request review is submitted / dismissed.
+# Run this action when a pull request review is submitted / dismissed.
 # Note that an approval can be dismissed, and this can affect the job status.
 # We currently trust that contributors won't make significant changes to their PRs after approval, so we accept
 # changes after approval.
@@ -10,7 +10,6 @@
 name: Check PR Approvals
 on:
   merge_group:
-  pull_request:
   pull_request_review:
     types: [submitted, dismissed]
 

--- a/.github/workflows/rustc.yml
+++ b/.github/workflows/rustc.yml
@@ -4,6 +4,7 @@
 name: Rust Tests
 on:
   workflow_dispatch:
+  merge_group:
   pull_request:
     branches: [ main ]
   push:


### PR DESCRIPTION
Add `merge_group` as a trigger for our workflows. For the review check workflow, I also added a review dismissed option, and for the `merge_group` case, the workflow does nothing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
