### PR TITLE
PR Approvals Workflow: Fetch Multiple Pages

### DIFF
--- a/.github/workflows/pr_approval.yml
+++ b/.github/workflows/pr_approval.yml
@@ -73,16 +73,42 @@ jobs:
               return;
             }
 
-            // Get all reviews
-            const reviews = await github.rest.pulls.listReviews({
-              owner,
-              repo,
-              pull_number
-            });
+            // Get all reviews with pagination
+            async function getAllReviews() {
+              let allReviews = [];
+              let page = 1;
+              let page_limit = 100;
+              
+              while (page < page_limit) {
+                const response = await github.rest.pulls.listReviews({
+                  owner,
+                  repo,
+                  pull_number,
+                  per_page: 100,
+                  page
+                });
+                
+                allReviews = allReviews.concat(response.data);
+                
+                if (response.data.length < 100) {
+                  break;
+                }
+                
+                page++;
+              }
+
+              if (page == page_limit) {
+                console.log(`WARNING: Reached page limit of ${page_limit} while fetching reviews data; approvals count may be less than the real total.`)
+              }
+              
+              return allReviews;
+            }
+
+            const reviews = await getAllReviews();
 
             // Example: approvers = ["celina", "zyad"]
             const approvers = new Set(
-              reviews.data
+              reviews
                 .filter(review => review.state === 'APPROVED')
                 .map(review => review.user.login)
             );


### PR DESCRIPTION
The `check_approvals` workflow in #107 fails because by default Github [only returns the first 30 results](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28#about-pagination) for GET requests to their API. #107 has more review activity than that, so the approvals are all on the second or third pages, hence why the workflow says zero approvals.

So, this PR updates the script to fetch 100 responses per page, up to 100 pages. These are arbitrary values, but I didn't want to have any infinite loops, and I can't imagine a realistic PR ever going above these numbers (and I put a warning in the script if they do).

I checked that this new workflow runs without error [on my fork](https://github.com/carolynzech/verify-rust-std/actions/runs/12267930897/job/34228889979?pr=20). I also did some experimentation in my local bash with the branch from #107 and verified that upping the pagination limits like this does indeed return the approvals on the later pages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
