### PR TITLE
Add review guidelines

### DIFF
--- a/doc/src/general-rules.md
+++ b/doc/src/general-rules.md
@@ -101,9 +101,12 @@ Reviews of solutions towards challenges should consider at least the following a
 1. Does the pull request implement a solution that respects/meets the success
    criteria of the challenge?
 2. Do the contracts and harnesses incorporate the safety conditions stated in
-   the documentation (from comments in the code and the [standard library documentation](https://doc.rust-lang.org/std/index.html))? Note that we
-   currently focus on safety verification. Pre- and post-conditions towards
-   functional correctness are acceptable as long as they do not negatively
-   impact verification of safety, such as over-constraining input values.
-3. Is the contributed code of adequate quality and idiomatic (to the best of the
-   committee member's knowledge).
+   the documentation (from comments in the code and the
+   [standard library documentation](https://doc.rust-lang.org/std/index.html))?
+   Note that we currently focus on safety verification. Pre- and post-conditions
+   towards functional correctness are acceptable as long as they do not
+   negatively impact verification of safety, such as over-constraining input
+   values or causing excessive verification run time.
+3. Is the contributed code of adequate quality, idiomatic, and stands a chance
+   to be accepted into the standard library (to the best of the committee
+   member's knowledge)?

--- a/doc/src/general-rules.md
+++ b/doc/src/general-rules.md
@@ -92,3 +92,18 @@ members = [
 +   "rahulku"
 ]
 ```
+
+Committee members are expected to contribute by reviewing pull requests (all
+pull requests review approvals from at least two committee members before they
+can be merged).
+Reviews of solutions towards challenges should consider at least the following aspects:
+
+1. Does the pull request implement a solution that respects/meets the success
+   criteria of the challenge?
+2. Do the contracts and harnesses incorporate the safety conditions stated in
+   the documentation (from comments in the code and Rust book)? Note that we
+   currently focus on safety verification. Pre- and post-conditions towards
+   functional correctness are acceptable as long as they do not negatively
+   impact verification of safety, such as over-constraining input values.
+3. Is the contributed code of adequate quality and idiomatic (to the best of the
+   committee member's knowledge).

--- a/doc/src/general-rules.md
+++ b/doc/src/general-rules.md
@@ -101,7 +101,7 @@ Reviews of solutions towards challenges should consider at least the following a
 1. Does the pull request implement a solution that respects/meets the success
    criteria of the challenge?
 2. Do the contracts and harnesses incorporate the safety conditions stated in
-   the documentation (from comments in the code and Rust book)? Note that we
+   the documentation (from comments in the code and the [standard library documentation](https://doc.rust-lang.org/std/index.html))? Note that we
    currently focus on safety verification. Pre- and post-conditions towards
    functional correctness are acceptable as long as they do not negatively
    impact verification of safety, such as over-constraining input values.


### PR DESCRIPTION
Extends committee membership information with guidance on what is expected of committee members.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
