### PR TITLE
Fix intrinsics challenge typo in summary

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -14,7 +14,7 @@
 
 - [Challenges](./challenges.md)
   - [1: Verify core transmuting methods](./challenges/0001-core-transmutation.md)
-  - [2: Verify the memory safery of core intrinsics using raw pointers](./challenges/0002-intrinsics-memory.md)
+  - [2: Verify the memory safety of core intrinsics using raw pointers](./challenges/0002-intrinsics-memory.md)
   - [3: Verifying Raw Pointer Arithmetic Operations](./challenges/0003-pointer-arithmentic.md)
   - [4: Memory safety of BTreeMap's `btree::node` module](./challenges/0004-btree-node.md)
   - [5: Verify functions iterating over inductive data type: `linked_list`](./challenges/0005-linked-list.md)


### PR DESCRIPTION
This PR fixes a minor typo in `SUMMARY.md` I noticed while browsing through the site.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
