### PR TITLE
Parallelize & Partition Verification

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -31,8 +31,10 @@ jobs:
       fail-fast: false
     
     env:
-      PARALLEL_INDEX: ${{ matrix.partition }}
-      PARALLEL_TOTAL: 4
+      # Define the index of this particular worker [1-WORKER_TOTAL]
+      WORKER_INDEX: ${{ matrix.partition }}
+      # Total number of workers running this step
+      WORKER_TOTAL: 4
     
     steps:
       # Step 1: Check out the repository

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -35,16 +35,19 @@ jobs:
       PARALLEL_TOTAL: 4
     
     steps:
+      # Step 1: Check out the repository
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           path: head
           submodules: true
-
+      
+      # Step 2: Install jq
       - name: Install jq
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install -y jq
-
+      
+      # Step 3: Run Kani on the std library (default configuration)
       - name: Run Kani Verification
         run: head/scripts/run-kani.sh --path ${{github.workspace}}/head
    

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -17,25 +17,34 @@ defaults:
 
 jobs:
   check-kani-on-std:
-    name: Verify std library
+    name: Verify std library (partition ${{ matrix.partition }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        partition: [1, 2, 3, 4]
         include:
           - os: ubuntu-latest
             base: ubuntu
           - os: macos-latest
             base: macos
+      fail-fast: false
+    
+    env:
+      PARALLEL_INDEX: ${{ matrix.partition }}
+      PARALLEL_TOTAL: 4
+    
     steps:
-      # Step 1: Check out the repository
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           path: head
           submodules: true
 
-      # Step 2: Run Kani on the std library (default configuration)
+      - name: Install jq
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install -y jq
+
       - name: Run Kani Verification
         run: head/scripts/run-kani.sh --path ${{github.workspace}}/head
    

--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -155,8 +155,9 @@ get_kani_path() {
     echo "$(realpath "$build_dir/scripts/kani")"
 }
 
-# Run kani list with JSON format and process with jq to extract all harness names
-# Note: This code is based on `kani list` JSON version 0.1 -- if the version changes, this logic may need to change as well.
+# Run kani list with JSON format and process with jq to extract harness names and total number of harnesses.
+# Note: The code to extract ALL_HARNESSES is dependent on `kani list --format json` FILE_VERSION 0.1.
+# If FILE_VERSION changes, this logic may need to change as well.
 get_harnesses() {
     local kani_path="$1"
     "$kani_path" list -Z list -Z function-contracts -Z mem-predicates -Z float-lib -Z c-ffi ./library --std --format json
@@ -168,6 +169,7 @@ get_harnesses() {
     HARNESS_COUNT=${#ALL_HARNESSES[@]}
 }
 
+# Given an array of harness names, run verification for those harnesses
 run_verification_subset() {
     local kani_path="$1"
     local harnesses=("${@:2}")  # All arguments after kani_path are harness names

--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -77,9 +77,20 @@ TOML_FILE=${KANI_TOML_FILE:-$DEFAULT_TOML_FILE}
 REPO_URL=${KANI_REPO_URL:-$DEFAULT_REPO_URL}
 BRANCH_NAME=${KANI_BRANCH_NAME:-$DEFAULT_BRANCH_NAME}
 
-# Kani list related variables, set in get_harnesses(); these are only used to parallelize harness verification
+# Variables used for parallel harness verification
+# When we say "parallel," we mean two dimensions of parallelization:
+#   1. Sharding verification across multiple workers. The Kani workflow that calls this script defines WORKER_INDEX and WORKER_TOTAL for this purpose: 
+#   we shard verification across WORKER_TOTAL workers, where each worker has a unique WORKER_INDEX that it uses to derive its share of ALL_HARNESSES to verify.
+#   2. Within a single worker, we parallelize verification between multiple cores by invoking kani with -j VERIFICATION_THREAD_COUNT.
+#   For now, VERIFICATION_THREAD_COUNT=4 since the Kani workflow runs on standard Github runners, which have 3-4 cores.
+#   TODO: If we move to larger runners, we should increase this number.
+
+# Array of all of the harnesses in the repository, set in get_harnesses()
 declare -a ALL_HARNESSES
+# Length of ALL_HARNESSES, set in get_harnesses()
 declare -i HARNESS_COUNT
+# Number of threads to spawn within a single worker to run Kani.
+declare -i VERIFICATION_THREAD_COUNT=4
 
 # Function to read commit ID from TOML file
 read_commit_from_toml() {
@@ -162,7 +173,7 @@ get_kani_path() {
 get_harnesses() {
     local kani_path="$1"
     "$kani_path" list -Z list -Z function-contracts -Z mem-predicates -Z float-lib -Z c-ffi ./library --std --format json
-    local json_file_version = $(jq -r '.["file-version"]' $WORK_DIR/kani-list.json)
+    local json_file_version=$(jq -r '.["file-version"]' "$WORK_DIR/kani-list.json")
     if [[ $json_file_version != "0.1" ]]; then
         echo "Error: The JSON file-version in kani-list.json does not equal 0.1."
         exit 1
@@ -253,27 +264,20 @@ main() {
     "$kani_path" --version
 
     if [[ "$run_command" == "verify-std" ]]; then
-        if [[ -n "$PARALLEL_INDEX" && -n "$PARALLEL_TOTAL" ]]; then
-            echo "Running as parallel worker $PARALLEL_INDEX of $PARALLEL_TOTAL"
+        if [[ -n "$WORKER_INDEX" && -n "$WORKER_TOTAL" ]]; then
+            echo "Running as parallel worker $WORKER_INDEX of $WORKER_TOTAL"
             get_harnesses "$kani_path"
 
             echo "All harnesses:"
             printf '%s\n' "${ALL_HARNESSES[@]}"
             echo "Total number of harnesses: $HARNESS_COUNT"
             
-            # Calculate this worker's portion
-            chunk_size=$(( (HARNESS_COUNT + PARALLEL_TOTAL - 1) / PARALLEL_TOTAL ))
+            # Calculate this worker's portion (add WORKER_TOTAL - 1 to force ceiling division)
+            chunk_size=$(( (HARNESS_COUNT + WORKER_TOTAL - 1) / WORKER_TOTAL ))
             echo "Number of harnesses this worker will run: $chunk_size"
             
-            start_idx=$(( (PARALLEL_INDEX - 1) * chunk_size ))
-            end_idx=$(( start_idx + chunk_size ))
-            # If end_idx > HARNESS_COUNT, truncate it to $HARNESS_COUNT
-            if [[ $end_idx > $HARNESS_COUNT ]]; then
-                end_idx=$HARNESS_COUNT
-            fi
-
+            start_idx=$(( (WORKER_INDEX - 1) * chunk_size ))
             echo "Start index into ALL_HARNESSES is $start_idx"
-            echo "End index into ALL_HARNESSES is $end_idx"
             
             # Extract this worker's harnesses
             worker_harnesses=("${ALL_HARNESSES[@]:$start_idx:$chunk_size}")

--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -195,6 +195,8 @@ run_verification_subset() {
         -Z float-lib \
         -Z c-ffi \
         $harness_args --exact \
+        -j $VERIFICATION_THREAD_COUNT \
+        --output-format=terse \
         $command_args \
         --enable-unstable \
         --cbmc-args --object-bits 12

--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -295,7 +295,7 @@ main() {
         fi
     elif [[ "$run_command" == "list" ]]; then
         echo "Running Kani list command..."
-        "$kani_path" list -Z list $unstable_flags ./library --std --format markdown
+        "$kani_path" list -Z list $unstable_args ./library --std --format markdown
     fi
 }
 

--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -81,16 +81,12 @@ BRANCH_NAME=${KANI_BRANCH_NAME:-$DEFAULT_BRANCH_NAME}
 # When we say "parallel," we mean two dimensions of parallelization:
 #   1. Sharding verification across multiple workers. The Kani workflow that calls this script defines WORKER_INDEX and WORKER_TOTAL for this purpose: 
 #   we shard verification across WORKER_TOTAL workers, where each worker has a unique WORKER_INDEX that it uses to derive its share of ALL_HARNESSES to verify.
-#   2. Within a single worker, we parallelize verification between multiple cores by invoking kani with -j VERIFICATION_THREAD_COUNT.
-#   For now, VERIFICATION_THREAD_COUNT=4 since the Kani workflow runs on standard Github runners, which have 3-4 cores.
-#   TODO: If we move to larger runners, we should increase this number.
+#   2. Within a single worker, we parallelize verification between multiple cores by invoking kani with -j.
 
 # Array of all of the harnesses in the repository, set in get_harnesses()
 declare -a ALL_HARNESSES
 # Length of ALL_HARNESSES, set in get_harnesses()
 declare -i HARNESS_COUNT
-# Number of threads to spawn within a single worker to run Kani.
-declare -i VERIFICATION_THREAD_COUNT=4
 
 # Function to read commit ID from TOML file
 read_commit_from_toml() {
@@ -206,7 +202,7 @@ run_verification_subset() {
         -Z float-lib \
         -Z c-ffi \
         $harness_args --exact \
-        -j $VERIFICATION_THREAD_COUNT \
+        -j \
         --output-format=terse \
         $command_args \
         --enable-unstable \

--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -178,7 +178,8 @@ run_verification_subset() {
         harness_args="$harness_args --harness $harness"
     done
 
-    echo "Running verification for harnesses: ${harnesses[*]}"
+    echo "Running verification for harnesses:"
+    printf '%s\n' "${harnesses[@]}"
     "$kani_path" verify-std -Z unstable-options ./library \
         -Z function-contracts \
         -Z mem-predicates \
@@ -245,12 +246,22 @@ main() {
         if [[ -n "$PARALLEL_INDEX" && -n "$PARALLEL_TOTAL" ]]; then
             echo "Running as parallel worker $PARALLEL_INDEX of $PARALLEL_TOTAL"
             get_harnesses "$kani_path"
+
+            echo "All harnesses:"
+            printf '%s\n' "${ALL_HARNESSES[@]}"
+            echo "Total number of harnesses: $HARNESS_COUNT"
             
             # Calculate this worker's portion
             chunk_size=$(( (HARNESS_COUNT + PARALLEL_TOTAL - 1) / PARALLEL_TOTAL ))
+            echo "Number of harnesses this worker will run: $chunk_size"
+            
             start_idx=$(( (PARALLEL_INDEX - 1) * chunk_size ))
             end_idx=$(( start_idx + chunk_size ))
+            # If end_idx > HARNESS_COUNT, truncate it to $HARNESS_COUNT
             [[ $end_idx -gt $HARNESS_COUNT ]] && end_idx=$HARNESS_COUNT
+
+            echo "Start index into ALL_HARNESSES is $start_idx"
+            echo "End index into ALL_HARNESSES is $end_idx"
             
             # Extract this worker's harnesses
             worker_harnesses=("${ALL_HARNESSES[@]:$start_idx:$chunk_size}")


### PR DESCRIPTION
Shard Kani verification workflow across multiple runners by:

1. Running `kani list --format json`, which outputs a JSON file like this:

```json
{
  "kani-version": "0.56.0",
  "file-version": "0.1",
  "standard-harnesses": {
    "src/lib.rs": [
      "proof3",
      "verify::proof2"
    ],
    "src/test.rs": [
      "test::proof4",
      "test::proof5"
    ]
  },
  "contract-harnesses": {
    "src/lib.rs": [
      "proof"
    ]
  },
  "contracts": [
    {
      "function": "bar",
      "file": "src/lib.rs",
      "harnesses": [
        "proof"
      ]
    }
  ],
  "totals": {
    "standard-harnesses": 4,
    "contract-harnesses": 1,
    "functions-under-contract": 1
  }
}
```
2. Extracting the harnesses inside `"standard-harnesses"` and `"contract-harnesses"` into an array called `ALL_HARNESSES` and the length of that array into `HARNESS_COUNT`. (So in this example, `ALL_HARNESSES = [proof3, verify::proof2, test::proof4, test::proof5, proof]` and `HARNESS_COUNT=5`).
3. Dividing the harnesses evenly between four workers. For example, if worker 1's harnesses are `proof3` and `verify::proof2`, then we call `kani verify-std --harness proof3 --harness verify::proof2 --exact`. The `--exact` makes Kani look for the exact harness name. This is important so that we don't match on partial patterns, e.g., if there is a harness called "foo" and a harness called "foo_bar", passing `--harness foo` without `--exact` would match against both harnesses, and then `foo_bar` would run twice.
4. Also parallelize verification within a single runner by passing `-j` to Kani.

I chose four workers somewhat arbitrarily--it makes each worker take about 45 minutes to an hour to finish. I thought it was good to have a balance between too few workers (which still makes us wait a while) and too many workers (which makes you look through more logs to find where a given harness is being verified). But happy to play with this number if people have opinions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
