### PR TITLE
Improve `u16::carrying_mul` harness performance

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -2048,9 +2048,10 @@ mod verify {
     );
 
     // ====================== u16 Harnesses ======================
-    /// Kani proof harness for `carrying_mul` on `u16` type with full range of values.
     generate_carrying_mul_intervals!(u16, u32,
-        carrying_mul_u16_full_range, 0u16, u16::MAX
+        carrying_mul_u16_small, 0u16, 10u16,
+        carrying_mul_u16_large, u16::MAX - 10u16, u16::MAX,
+        carrying_mul_u16_mid_edge, (u16::MAX / 2) - 10u16, (u16::MAX / 2) + 10u16
     );
 
     // ====================== u32 Harnesses ======================

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -2049,6 +2049,7 @@ mod verify {
     );
 
     // ====================== u16 Harnesses ======================
+    /// Kani proof harness for `carrying_mul` on `u16` type with full range of values.
     generate_carrying_mul_intervals!(u16, u32,
         carrying_mul_u16_full_range, 0u16, u16::MAX
     );

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1759,6 +1759,7 @@ mod verify {
         ($type:ty, $wide_type:ty, $($harness_name:ident, $min:expr, $max:expr),+) => {
             $(
                 #[kani::proof]
+                #[kani::solver(kissat)]
                 pub fn $harness_name() {
                     let lhs: $type = kani::any::<$type>();
                     let rhs: $type = kani::any::<$type>();
@@ -2049,9 +2050,7 @@ mod verify {
 
     // ====================== u16 Harnesses ======================
     generate_carrying_mul_intervals!(u16, u32,
-        carrying_mul_u16_small, 0u16, 10u16,
-        carrying_mul_u16_large, u16::MAX - 10u16, u16::MAX,
-        carrying_mul_u16_mid_edge, (u16::MAX / 2) - 10u16, (u16::MAX / 2) + 10u16
+        carrying_mul_u16_full_range, 0u16, u16::MAX
     );
 
     // ====================== u32 Harnesses ======================


### PR DESCRIPTION
This harness takes between 22-25 minutes in CI. Change the harnesses's macro to use kissat solver instead, which brings verification time down to ~7 seconds.

As an aside, I noticed this problem because the partition 1 runner in #229 is taking ~55 minutes, where the other partitions are taking ~30 minutes. This harness accounts for almost the entire difference. One nice consequence of partitioning verification is that it will make performance issues like this more noticeable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
