### PR TITLE
Add missing line separator

### DIFF
--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -288,7 +288,7 @@ main() {
             # Run verification for all harnesses (not in parallel)
             echo "Running Kani verify-std command..."
             "$kani_path" verify-std -Z unstable-options ./library \
-                $unstable_args
+                $unstable_args \
                 $command_args \
                 --enable-unstable \
                 --cbmc-args --object-bits 12


### PR DESCRIPTION
Fix a typo introduced in #229 that prevents `kani-args` from getting passed to the `kani` command.

This was discovered by @tengjiang (see https://github.com/model-checking/verify-rust-std/discussions/231).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
