### PR TITLE
Add goto-transcoder.md into summary

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -8,6 +8,7 @@
 
 - [Verification Tools](./tools.md)
   - [Kani](./tools/kani.md)
+  - [GOTO Transcoder](./tools/goto-transcoder.md)
 
 ---
 


### PR DESCRIPTION
The goto-transcoder is not appearing in the book pages. This should fix it.