### PR TITLE
Fix link rendering in 0015-intrinsics-simd.md

### DIFF
--- a/doc/src/challenges/0015-intrinsics-simd.md
+++ b/doc/src/challenges/0015-intrinsics-simd.md
@@ -3,7 +3,7 @@
 - **Status:** Open
 - **Reward:** 
 - **Solution:** 
-- **Tracking Issue:** https://github.com/model-checking/verify-rust-std/issues/173
+- **Tracking Issue:** [#173](https://github.com/model-checking/verify-rust-std/issues/173)
 - **Start date:** 2025/02/01
 - **End date:** 2025/08/01
 


### PR DESCRIPTION
https://model-checking.github.io/verify-rust-std/challenges does not autoconvert github issue links

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
