### PR TITLE
Implement kani::Arbitrary for Wrapping, Saturating, and Simd types

### DIFF
--- a/library/core/src/num/saturating.rs
+++ b/library/core/src/num/saturating.rs
@@ -35,8 +35,15 @@ use crate::ops::{
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default, Hash)]
 #[repr(transparent)]
 #[rustc_diagnostic_item = "Saturating"]
-#[cfg_attr(kani, derive(kani::Arbitrary))]
 pub struct Saturating<T>(#[stable(feature = "saturating_int_impl", since = "1.74.0")] pub T);
+
+#[cfg(kani)]
+#[stable(feature = "saturating_int_impl", since = "1.74.0")]
+impl<T: kani::Arbitrary> kani::Arbitrary for Saturating<T> {
+    fn any() -> Self {
+        Self { 0: kani::any() }
+    }
+}
 
 #[stable(feature = "saturating_int_impl", since = "1.74.0")]
 impl<T: fmt::Debug> fmt::Debug for Saturating<T> {

--- a/library/core/src/num/saturating.rs
+++ b/library/core/src/num/saturating.rs
@@ -1,6 +1,8 @@
 //! Definitions of `Saturating<T>`.
 
 use crate::fmt;
+#[cfg(kani)]
+use crate::kani;
 use crate::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
     Mul, MulAssign, Neg, Not, Rem, RemAssign, Sub, SubAssign,

--- a/library/core/src/num/saturating.rs
+++ b/library/core/src/num/saturating.rs
@@ -35,6 +35,7 @@ use crate::ops::{
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default, Hash)]
 #[repr(transparent)]
 #[rustc_diagnostic_item = "Saturating"]
+#[cfg_attr(kani, derive(kani::Arbitrary))]
 pub struct Saturating<T>(#[stable(feature = "saturating_int_impl", since = "1.74.0")] pub T);
 
 #[stable(feature = "saturating_int_impl", since = "1.74.0")]

--- a/library/core/src/num/wrapping.rs
+++ b/library/core/src/num/wrapping.rs
@@ -40,8 +40,15 @@ use crate::ops::{
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default, Hash)]
 #[repr(transparent)]
 #[rustc_diagnostic_item = "Wrapping"]
-#[cfg_attr(kani, derive(kani::Arbitrary))]
 pub struct Wrapping<T>(#[stable(feature = "rust1", since = "1.0.0")] pub T);
+
+#[cfg(kani)]
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: kani::Arbitrary> kani::Arbitrary for Wrapping<T> {
+    fn any() -> Self {
+        Self { 0: kani::any() }
+    }
+}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: fmt::Debug> fmt::Debug for Wrapping<T> {

--- a/library/core/src/num/wrapping.rs
+++ b/library/core/src/num/wrapping.rs
@@ -40,6 +40,7 @@ use crate::ops::{
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default, Hash)]
 #[repr(transparent)]
 #[rustc_diagnostic_item = "Wrapping"]
+#[cfg_attr(kani, derive(kani::Arbitrary))]
 pub struct Wrapping<T>(#[stable(feature = "rust1", since = "1.0.0")] pub T);
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/num/wrapping.rs
+++ b/library/core/src/num/wrapping.rs
@@ -1,6 +1,8 @@
 //! Definitions of `Wrapping<T>`.
 
 use crate::fmt;
+#[cfg(kani)]
+use crate::kani;
 use crate::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
     Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,

--- a/library/portable-simd/crates/core_simd/src/vector.rs
+++ b/library/portable-simd/crates/core_simd/src/vector.rs
@@ -5,6 +5,9 @@ use crate::simd::{
     ptr::{SimdConstPtr, SimdMutPtr},
 };
 
+#[cfg(kani)]
+use crate::kani;
+
 /// A SIMD vector with the shape of `[T; N]` but the operations of `T`.
 ///
 /// `Simd<T, N>` supports the operators (+, *, etc.) that `T` does in "elementwise" fashion.
@@ -100,6 +103,7 @@ use crate::simd::{
 // avoided, as it will likely become illegal on `#[repr(simd)]` structs in the future. It also
 // causes rustc to emit illegal LLVM IR in some cases.
 #[repr(simd, packed)]
+#[cfg_attr(kani, derive(kani::Arbitrary))]
 pub struct Simd<T, const N: usize>([T; N])
 where
     LaneCount<N>: SupportedLaneCount,


### PR DESCRIPTION
Implement `kani::Arbitrary` for the `Wrapping`, `Saturating`, and `Simd` types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
