### PR TITLE
Fix typo in comment ('contact' -> 'contract')

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -2614,7 +2614,7 @@ mod verify {
     gen_const_byte_arith_harness_for_dyn!(byte_sub, check_const_byte_sub_dyn);
     gen_const_byte_arith_harness_for_dyn!(byte_offset, check_const_byte_offset_dyn);
 
-    // Proof for contact of byte_offset_from to verify unit type
+    // Proof for contract of byte_offset_from to verify unit type
     #[kani::proof_for_contract(<*const ()>::byte_offset_from)]
     pub fn check_const_byte_offset_from_unit() {
         let val: () = ();


### PR DESCRIPTION
I was grepping for contract and this one didn't match because of the typo. Minor comment-only change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
