### PR TITLE
Use uname -m instead of uname -p

### DIFF
--- a/scripts/kani-std-analysis/std-analysis.sh
+++ b/scripts/kani-std-analysis/std-analysis.sh
@@ -18,7 +18,7 @@
 set -eu
 
 # Test for platform
-PLATFORM=$(uname -sp)
+PLATFORM=$(uname -sm)
 if [[ $PLATFORM == "Linux x86_64" ]]
 then
   TARGET="x86_64-unknown-linux-gnu"


### PR DESCRIPTION
On my Debian machine, uname -p returns "unknown" and the manpage says -p is non-portable. I do get x86_64 on from uname -m and that doesn't have the non-portable disclaimer on it.

> Please add a description of your PR.
> If this is a solution to an open challenge, please explain your solution.
>
> Don't forget to check our book to ensure your solution satisfy the overall
> requirements as well as the challenge success criteria.
>

Resolves #ISSUE-NUMBER

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
