### PR TITLE
Kani: use -Z unstable-options instead of --enable-unstable

### DIFF
--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -218,7 +218,7 @@ run_verification_subset() {
         -j \
         --output-format=terse \
         "${command_args[@]}" \
-        --enable-unstable \
+        -Z unstable-options \
         --cbmc-args --object-bits 12
 }
 
@@ -300,7 +300,7 @@ main() {
                 $unstable_args \
                 --no-assert-contracts \
                 "${command_args[@]}" \
-                --enable-unstable \
+                -Z unstable-options \
                 --cbmc-args --object-bits 12
         fi
       elif [[ "$run_command" == "autoharness" ]]; then
@@ -311,7 +311,7 @@ main() {
               $unstable_args \
               --no-assert-contracts \
               "${command_args[@]}" \
-              --enable-unstable \
+              -Z unstable-options \
               --cbmc-args --object-bits 12
     elif [[ "$run_command" == "list" ]]; then
         echo "Running Kani list command..."
@@ -347,7 +347,7 @@ main() {
             $unstable_args \
             --no-assert-contracts \
             "${command_args[@]}" \
-            --enable-unstable \
+            -Z unstable-options \
             --cbmc-args --object-bits 12
         # remove metadata file for Kani-generated "dummy" crate that we won't
         # get scanner data for

--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -218,7 +218,6 @@ run_verification_subset() {
         -j \
         --output-format=terse \
         "${command_args[@]}" \
-        -Z unstable-options \
         --cbmc-args --object-bits 12
 }
 
@@ -300,7 +299,6 @@ main() {
                 $unstable_args \
                 --no-assert-contracts \
                 "${command_args[@]}" \
-                -Z unstable-options \
                 --cbmc-args --object-bits 12
         fi
       elif [[ "$run_command" == "autoharness" ]]; then
@@ -311,7 +309,6 @@ main() {
               $unstable_args \
               --no-assert-contracts \
               "${command_args[@]}" \
-              -Z unstable-options \
               --cbmc-args --object-bits 12
     elif [[ "$run_command" == "list" ]]; then
         echo "Running Kani list command..."
@@ -347,7 +344,6 @@ main() {
             $unstable_args \
             --no-assert-contracts \
             "${command_args[@]}" \
-            -Z unstable-options \
             --cbmc-args --object-bits 12
         # remove metadata file for Kani-generated "dummy" crate that we won't
         # get scanner data for


### PR DESCRIPTION
`--enable-unstable` has been removed from Kani's latest version and will, thus, break upgrading to a newer Kani version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
