### PR TITLE
Updates for goto-transcoder and ESBMC

### DIFF
--- a/scripts/run-goto-transcoder.sh
+++ b/scripts/run-goto-transcoder.sh
@@ -9,8 +9,8 @@ contract_folder=$1/kani_verify_std/target/x86_64-unknown-linux-gnu/debug/deps
 supported_regex=$2
 unsupported_regex=neg
 
-goto_transcoder_git=https://github.com/rafaelsamenezes/goto-transcoder
-esbmc_url=https://github.com/esbmc/esbmc/releases/download/nightly-7867f5e5595b9e181cd36eb9155d1905f87ad241/esbmc-linux.zip
+goto_transcoder_git=https://github.com/esbmc/goto-transcoder
+esbmc_url=https://github.com/esbmc/esbmc/releases/download/nightly-39b012f9f7f7dad188708a9eaf4bbbc5faa3b4f7/esbmc-linux.zip
 
 ##########
 # SCRIPT #
@@ -44,8 +44,8 @@ while IFS= read -r line; do
         continue
     fi
     echo "Running: goto-transcoder $contract $contract_folder/$line $contract.esbmc.goto"
-    cargo run cbmc2esbmc $contract ../$contract_folder/$line $contract.esbmc.goto
-    ./linux-release/bin/esbmc --binary $contract.esbmc.goto
+    cargo run cbmc2esbmc  ../$contract_folder/$line $contract.esbmc.goto
+    ./linux-release/bin/esbmc --cprover --function $contract --binary resources/library.goto $contract.esbmc.goto
 done < "_contracts.txt"
 
 rm "_contracts.txt"


### PR DESCRIPTION
This PR updates:

- Goto-transcoder: moved ownership to esbmc organization. 
- ESBMC: goto-transcoder is now compatible with the latest nightly of ESBMC.

The latest version of esbmc fixes https://github.com/rafaelsamenezes/goto-transcoder/issues/4, removing the necessity of setting the entrypoint through goto-transcoder.