### PR TITLE
Subtree update automation: update submodules

### DIFF
--- a/.github/workflows/update-subtree.yml
+++ b/.github/workflows/update-subtree.yml
@@ -85,6 +85,7 @@ jobs:
       if: ${{ env.SUBTREE_PR_EXISTS == 'no' }}
       run: |
         cd splitsh-lite
+        sudo apt-get update
         sudo apt-get install -y golang libgit2-dev
         # git2go upstream hasn't been updated to more recent versions of
         # libgit2, so using a fork that does stay up to date
@@ -110,6 +111,10 @@ jobs:
         fi
 
         git checkout ${NEXT_COMMIT_HASH}
+        # Collect submodule commits; note that submodules (intentionally!)
+        # aren't initialized, hence lines will be prefixed with "-" (see git
+        # submodule --help).
+        git submodule status  -- library/ | sed 's/^-//' > ../submodule-heads
         /usr/bin/time -v ../splitsh-lite/splitsh-lite --progress --prefix=library --target subtree/library
         git checkout -b subtree/library subtree/library
 
@@ -165,6 +170,7 @@ jobs:
           fi
         fi
         git checkout main
+        git submodule foreach 'git fetch'
 
         # Tell git about the correct merge base to use, which is the subtree
         # head that we last merged from.
@@ -178,6 +184,8 @@ jobs:
             -c user.name=gitbot -c user.email=git@bot \
             merge -Xsubtree=library subtree/library; then
           echo "MERGE_CONFLICTS=yes" >> $GITHUB_ENV
+          # Ignore submodule conflicts, those are dealt with below.
+          for d in $(cat ../submodule-heads | cut -f2 -d" ") ; do git reset HEAD $d ; done
           git -c user.name=gitbot -c user.email=git@bot commit -a -m "Merge from $NEXT_COMMIT_HASH with conflicts"
         else
           echo "MERGE_CONFLICTS=no" >> $GITHUB_ENV
@@ -186,6 +194,12 @@ jobs:
         git replace -d main~1
         NEW_SUBTREE_HEAD=$(git rev-parse subtree/library)
         echo "NEW_SUBTREE_HEAD=${NEW_SUBTREE_HEAD}" >> $GITHUB_ENV
+
+        # Set submodules to upstream versions
+        git submodule update --init
+        git submodule foreach 'grep $sm_path $toplevel/../submodule-heads | cut -f1 -d" " | xargs git checkout'
+        git -c user.name=gitbot -c user.email=git@bot \
+          commit -m "Update submodules" library/
 
         sed -i "s/^channel = \"nightly-.*\"/channel = \"nightly-${NEXT_TOOLCHAIN_DATE}\"/" rust-toolchain.toml
         git -c user.name=gitbot -c user.email=git@bot \


### PR DESCRIPTION
Update submodules to the exact version that upstream uses at the commit that we are trying to merge towards. We never modify the contents of submodules, so we don't need to make any attempt to merge changes and instead can directly pick the right upstream version.

See https://github.com/tautschnig/verify-rust-std/actions/runs/15846078305/job/44668465448 for a successful run and https://github.com/tautschnig/verify-rust-std/pull/25 for the ensuing PR (which, notably, includes [a commit that bumps submodules](https://github.com/tautschnig/verify-rust-std/pull/25/commits/54d1d407a20917a07729abd602d9d0c3f67a335f)).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
