### PR TITLE
Fix subtree automation for submodules when there were no changes

### DIFF
--- a/.github/workflows/update-subtree.yml
+++ b/.github/workflows/update-subtree.yml
@@ -198,8 +198,10 @@ jobs:
         # Set submodules to upstream versions
         git submodule update --init
         git submodule foreach 'grep $sm_path $toplevel/../submodule-heads | cut -f1 -d" " | xargs git checkout'
-        git -c user.name=gitbot -c user.email=git@bot \
-          commit -m "Update submodules" library/
+        if ! git diff --quiet; then
+          git -c user.name=gitbot -c user.email=git@bot \
+            commit -m "Update submodules" library/
+        fi
 
         sed -i "s/^channel = \"nightly-.*\"/channel = \"nightly-${NEXT_TOOLCHAIN_DATE}\"/" rust-toolchain.toml
         git -c user.name=gitbot -c user.email=git@bot \


### PR DESCRIPTION
While the prior fixes made sure that submodule changes are picked up, the attempt to commit would fail when there were _no_ changes. See https://github.com/model-checking/verify-rust-std/actions/runs/15878565075/job/44772389751 for a failing run.

Now we will only attempt to commit when there are changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
