### PR TITLE
Don't run update-subtree.yml in forks

### DIFF
--- a/.github/workflows/update-subtree.yml
+++ b/.github/workflows/update-subtree.yml
@@ -11,6 +11,7 @@ defaults:
 
 jobs:
   update-subtree-library:
+    if: github.repository == 'model-checking/verify-rust-std'
     # Changing the host platform may alter the libgit2 version as used by
     # splitsh-lite, which will require changing the version of git2go.
     # See https://github.com/jeffWelling/git2go?tab=readme-ov-file#which-go-version-to-use


### PR DESCRIPTION
Currently, I receive a workflow run failure notification in my mailbox every day because this workflow runs in my fork.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
