### PR TITLE
Fix table in 0025-vecdeque.md

### DIFF
--- a/doc/src/challenges/0025-vecdeque.md
+++ b/doc/src/challenges/0025-vecdeque.md
@@ -38,6 +38,8 @@ Write and prove the contract for the safety of the following unsafe functions:
 
 Prove the absence of undefined behavior for following safe abstractions:
 
+| Function |
+|---------|
 |get|
 |get_mut|
 |swap|


### PR DESCRIPTION
Fixes a broken Markdown table in the Challenge 25 description.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
