### PR TITLE
Add missing line breaks in 0020-str-pattern-pt1.md

### DIFF
--- a/doc/src/challenges/0020-str-pattern-pt1.md
+++ b/doc/src/challenges/0020-str-pattern-pt1.md
@@ -39,6 +39,7 @@ The following str library functions are generic over the `Pattern` trait (https:
 - `strip_prefix`
 - `strip_suffix`
 - `trim_end_matches`
+
 These functions accept a pattern as input, then call [into_searcher](https://doc.rust-lang.org/std/str/pattern/trait.Pattern.html#tymethod.into_searcher) to create a [Searcher](https://doc.rust-lang.org/std/str/pattern/trait.Pattern.html#associatedtype.Searcher) for the pattern. They use this `Searcher` to perform their desired operations (split, find, etc.).
 Those functions are implemented in (library/core/src/str/mod.rs), but the core of them are the searching algorithms which are implemented in (library/core/src/str/pattern.rs).
 
@@ -72,6 +73,7 @@ Verify the safety of the following functions in (library/core/src/str/pattern.rs
 - `next_match_back`
 - `next_reject`
 - `next_back_reject`
+
 for the following `Searcher`s: 
 - `CharSearcher`
 - `MultiCharEqSearcher`


### PR DESCRIPTION
The description for Challenge 20 did not show correctly on GitHub Pages due to missing line breaks after an enumeration. This PR adds those missing line breaks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
