### PR TITLE
Update ESBMC link

### DIFF
--- a/scripts/run-goto-transcoder.sh
+++ b/scripts/run-goto-transcoder.sh
@@ -24,7 +24,7 @@ if [ ! -d "goto-transcoder" ]; then
     cd goto-transcoder
     wget $esbmc_url
     unzip esbmc-linux.zip
-    chmod +x ./linux-release/bin/esbmc
+    chmod +x ./bin/esbmc
     cd ..
 fi
 
@@ -45,7 +45,7 @@ while IFS= read -r line; do
     fi
     echo "Running: goto-transcoder $contract $contract_folder/$line $contract.esbmc.goto"
     cargo run cbmc2esbmc  ../$contract_folder/$line $contract.esbmc.goto
-    ./linux-release/bin/esbmc --cprover --function $contract --binary resources/library.goto $contract.esbmc.goto
+    ./bin/esbmc --cprover --function $contract --binary resources/library.goto $contract.esbmc.goto
 done < "_contracts.txt"
 
 rm "_contracts.txt"

--- a/scripts/run-goto-transcoder.sh
+++ b/scripts/run-goto-transcoder.sh
@@ -10,7 +10,7 @@ supported_regex=$2
 unsupported_regex=neg
 
 goto_transcoder_git=https://github.com/esbmc/goto-transcoder
-esbmc_url=https://github.com/esbmc/esbmc/releases/download/nightly-39b012f9f7f7dad188708a9eaf4bbbc5faa3b4f7/esbmc-linux.zip
+esbmc_url=https://github.com/esbmc/esbmc/releases/download/v7.10/esbmc-linux.zip
 
 ##########
 # SCRIPT #


### PR DESCRIPTION
The previous link for ESBMC is now dead, breaking the CI. This updates goto transcoder to use the latest version of ESBMC.