### PR TITLE
ci: only run update-kani-metrics in model-checking/verify-rust-std

### DIFF
--- a/.github/workflows/kani-metrics.yml
+++ b/.github/workflows/kani-metrics.yml
@@ -11,6 +11,7 @@ defaults:
 
 jobs:
   update-kani-metrics:
+    if: github.repository == 'model-checking/verify-rust-std'
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
Fork repos will auto run this job, thus bot PRs are weekly created due to autoharness and frequent API changes in libstd.

So this commit disables the job for fork repos.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
