### PR TITLE
Workaround sporadic git submodule failure

### DIFF
--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -132,7 +132,9 @@ setup_kani_repo() {
 
     git fetch --depth 1 origin "$commit" --quiet
     git checkout "$commit" --quiet
-    git submodule update --init --recursive --depth 1 --quiet
+    # Workaround for occasionally failing to copy a file in s2n-quic that we
+    # don't actually care about
+    GIT_LFS_SKIP_SMUDGE=1 git submodule update --init --recursive --depth 1 --quiet
     popd > /dev/null
 }
 


### PR DESCRIPTION
This is to avoid sporadic failures when trying to download the fuzzing corpus for s2n-quic (a Kani submodule). See https://github.com/model-checking/verify-rust-std/actions/runs/17576564986/job/49923064743 for an example of such a run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
