### PR TITLE
Clarify documentation of `can_dereference` with write permissions

### DIFF
--- a/library/core/src/ub_checks.rs
+++ b/library/core/src/ub_checks.rs
@@ -192,7 +192,7 @@ pub use predicates::*;
 #[cfg(not(kani))]
 mod predicates {
     /// Checks if a pointer can be dereferenced, ensuring:
-    ///   * `src` is valid for reads (see [`crate::ptr`] documentation).
+    ///   * `src` is valid for reads and writes (see [`crate::ptr`] documentation).
     ///   * `src` is properly aligned (use `read_unaligned` if not).
     ///   * `src` points to a properly initialized value of type `T`.
     ///


### PR DESCRIPTION
Clarify that `can_dereference` asserts a pointer has both read and write permissions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
