### PR TITLE
Challenge 2 (partial): safety contracts + verification for 15 of 20 raw-pointer core::intrinsics

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2555,6 +2555,16 @@ pub const fn is_val_statically_known<T: Copy>(_arg: T) -> bool {
     false
 }
 
+/// Shared fallback body of [`typed_swap_nonoverlapping`], factored out so the
+/// Kani verification wrapper can execute the same code the intrinsic falls back to.
+#[rustc_const_stable_indirect] // must follow stable const rules: reachable from the const-stable-indirect intrinsic below
+#[inline]
+const unsafe fn typed_swap_nonoverlapping_fallback<T>(x: *mut T, y: *mut T) {
+    // SAFETY: The caller provided single non-overlapping items behind
+    // pointers, so swapping them with `count: 1` is fine.
+    unsafe { ptr::swap_nonoverlapping(x, y, 1) };
+}
+
 /// Non-overlapping *typed* swap of a single value.
 ///
 /// The codegen backends will replace this with a better implementation when
@@ -2587,9 +2597,8 @@ pub const fn is_val_statically_known<T: Copy>(_arg: T) -> bool {
 #[requires(ub_checks::maybe_is_nonoverlapping(x as *const (), y as *const (), size_of::<T>(), 1))]
 #[ensures(|_| ub_checks::can_dereference(x) && ub_checks::can_dereference(y))]
 pub const unsafe fn typed_swap_nonoverlapping<T>(x: *mut T, y: *mut T) {
-    // SAFETY: The caller provided single non-overlapping items behind
-    // pointers, so swapping them with `count: 1` is fine.
-    unsafe { ptr::swap_nonoverlapping(x, y, 1) };
+    // SAFETY: Same contract as this intrinsic; forwarded verbatim to the shared fallback.
+    unsafe { typed_swap_nonoverlapping_fallback(x, y) };
 }
 
 /// Returns whether we should perform some UB-checking at runtime. This eventually evaluates to
@@ -3499,12 +3508,13 @@ mod verify {
         });
     }
 
-    // Kani models `typed_swap_nonoverlapping` with `codegen_swap` instead of its fallback body.
-    // This wrapper copies that body so `#[kani::proof_for_contract]` executes it.
+    // Kani models `typed_swap_nonoverlapping` itself with `codegen_swap`, so
+    // `#[kani::proof_for_contract]` can never enter its fallback body directly. This wrapper
+    // and the intrinsic's fallback body both call the same shared helper,
+    // `typed_swap_nonoverlapping_fallback`, so proving this wrapper against the contract proves
+    // the production fallback path too, and the two cannot drift apart.
     // `ptr::swap_nonoverlapping` reaches `copy_nonoverlapping`, never `typed_swap_nonoverlapping`.
     // The proof is therefore not circular.
-    // Scope limit: this proves the copied fallback meets the contract, not that it equals
-    // `codegen_swap`. Sharing the body would require an out-of-scope std-source refactor.
     #[cfg_attr(kani, kani::modifies(x))]
     #[cfg_attr(kani, kani::modifies(y))]
     #[requires(ub_checks::can_dereference(x) && ub_checks::can_write(x))]
@@ -3514,7 +3524,7 @@ mod verify {
     #[ensures(|_| ub_checks::can_dereference(x) && ub_checks::can_dereference(y))]
     #[allow(dead_code)]
     unsafe fn typed_swap_fallback_wrapper<T>(x: *mut T, y: *mut T) {
-        unsafe { crate::ptr::swap_nonoverlapping(x, y, 1) }
+        unsafe { typed_swap_nonoverlapping_fallback(x, y) }
     }
 
     #[kani::proof_for_contract(typed_swap_fallback_wrapper)]

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2941,12 +2941,12 @@ pub const fn ptr_metadata<P: ptr::Pointee<Metadata = M> + PointeeSized, M>(ptr: 
 
 /// Return whether the initialization state is preserved.
 ///
-/// For untyped copy, done via `copy` and `copy_nonoverlapping`, the copies of non-initialized
-/// bytes (such as padding bytes) should result in a non-initialized copy, while copies of
-/// initialized bytes result in initialized bytes.
+/// For untyped copy (`copy` and `copy_nonoverlapping`), copying an uninitialized byte (such as a
+/// padding byte) produces an uninitialized byte. Copying an initialized byte produces an
+/// initialized byte.
 ///
-/// It is UB to read the uninitialized bytes, so we cannot compare their values only their
-/// initialization state.
+/// Reading an uninitialized byte is UB, so this check compares only initialization state, never
+/// byte values.
 ///
 /// This is used for contracts only.
 #[allow(dead_code)]
@@ -2956,11 +2956,11 @@ fn check_copy_untyped<T>(src: *const T, dst: *mut T, count: usize) -> bool {
     if count > 0 {
         // Inspect a non-deterministically chosen byte in the copy.
         let byte = kani::any_where(|sz: &usize| *sz < size_of::<T>());
-        // Instead of checking each of the `count`-many copies, non-deterministically pick one of
-        // them and check it. Using quantifiers would not add value as we can rely on the solver to
-        // pick an uninitialized element if such an element exists.
+        // Instead of checking every one of the `count` copies, this picks one
+        // non-deterministically and inspects it. Quantifiers add no value here: the solver already
+        // picks an uninitialized element if one exists.
         let elem = kani::any_where(|val: &usize| *val < count);
-        let src_data = src as *const u8;
+        let src_data = unsafe { src.add(elem) } as *const u8;
         let dst_data = unsafe { dst.add(elem) } as *const u8;
         ub_checks::can_dereference(unsafe { src_data.add(byte) })
             == ub_checks::can_dereference(unsafe { dst_data.add(byte) })
@@ -3479,6 +3479,8 @@ mod verify {
 
     use super::*;
     use crate::kani;
+    // Provides `T::IS_ZST` for `write_bytes_wrapper`.
+    use crate::mem::SizedTypeProperties;
 
     #[kani::proof_for_contract(typed_swap_nonoverlapping)]
     pub fn check_typed_swap_u8() {
@@ -3497,36 +3499,126 @@ mod verify {
         });
     }
 
-    // #[kani::proof_for_contract(copy)]
-    // fn check_copy() {
-    //     run_with_arbitrary_ptrs::<char>(|src, dst| unsafe { copy(src, dst, kani::any()) });
-    // }
+    // Kani models `typed_swap_nonoverlapping` with `codegen_swap` instead of its fallback body.
+    // This wrapper copies that body so `#[kani::proof_for_contract]` executes it.
+    // `ptr::swap_nonoverlapping` reaches `copy_nonoverlapping`, never `typed_swap_nonoverlapping`.
+    // The proof is therefore not circular.
+    // Scope limit: this proves the copied fallback meets the contract, not that it equals
+    // `codegen_swap`. Sharing the body would require an out-of-scope std-source refactor.
+    #[cfg_attr(kani, kani::modifies(x))]
+    #[cfg_attr(kani, kani::modifies(y))]
+    #[requires(ub_checks::can_dereference(x) && ub_checks::can_write(x))]
+    #[requires(ub_checks::can_dereference(y) && ub_checks::can_write(y))]
+    #[requires(x.addr() != y.addr() || core::mem::size_of::<T>() == 0)]
+    #[requires(ub_checks::maybe_is_nonoverlapping(x as *const (), y as *const (), size_of::<T>(), 1))]
+    #[ensures(|_| ub_checks::can_dereference(x) && ub_checks::can_dereference(y))]
+    #[allow(dead_code)]
+    unsafe fn typed_swap_fallback_wrapper<T>(x: *mut T, y: *mut T) {
+        unsafe { crate::ptr::swap_nonoverlapping(x, y, 1) }
+    }
 
-    // #[kani::proof_for_contract(copy_nonoverlapping)]
-    // fn check_copy_nonoverlapping() {
-    //     // Note: cannot use `ArbitraryPointer` here.
-    //     // The `ArbitraryPtr` will arbitrarily initialize memory by indirectly invoking
-    //     // `copy_nonoverlapping`.
-    //     // Kani contract checking would fail due to existing restriction on calls to
-    //     // the function under verification.
-    //     let gen_any_ptr = |buf: &mut [MaybeUninit<char>; 100]| -> *mut char {
-    //         let base = buf.as_mut_ptr() as *mut u8;
-    //         base.wrapping_add(kani::any_where(|offset: &usize| *offset < 400)) as *mut char
-    //     };
-    //     let mut buffer1 = [MaybeUninit::<char>::uninit(); 100];
-    //     for i in 0..100 {
-    //         if kani::any() {
-    //             buffer1[i] = MaybeUninit::new(kani::any());
-    //         }
-    //     }
-    //     let mut buffer2 = [MaybeUninit::<char>::uninit(); 100];
-    //     let src = gen_any_ptr(&mut buffer1);
-    //     let dst = if kani::any() { gen_any_ptr(&mut buffer2) } else { gen_any_ptr(&mut buffer1) };
-    //     unsafe { copy_nonoverlapping(src, dst, kani::any()) }
-    // }
+    #[kani::proof_for_contract(typed_swap_fallback_wrapper)]
+    pub fn check_typed_swap_fallback_u8() {
+        run_with_arbitrary_ptrs::<u8>(|x, y| unsafe { typed_swap_fallback_wrapper(x, y) });
+    }
 
-    //We need this wrapper because transmute_unchecked is an intrinsic, for which Kani does
-    //not currently support contracts (https://github.com/model-checking/kani/issues/3345)
+    #[kani::proof_for_contract(typed_swap_fallback_wrapper)]
+    pub fn check_typed_swap_fallback_char() {
+        run_with_arbitrary_ptrs::<char>(|x, y| unsafe { typed_swap_fallback_wrapper(x, y) });
+    }
+
+    #[kani::proof_for_contract(typed_swap_fallback_wrapper)]
+    pub fn check_typed_swap_fallback_non_zero() {
+        run_with_arbitrary_ptrs::<core::num::NonZeroI32>(|x, y| unsafe {
+            typed_swap_fallback_wrapper(x, y)
+        });
+    }
+
+    // kani#3325 rejects contracts on no-body intrinsics. These wrappers carry the contracts.
+    // This is the same workaround used for `transmute_unchecked` in kani#3345.
+    #[requires(!count.overflowing_mul(size_of::<T>()).1
+        && ub_checks::can_dereference(core::ptr::slice_from_raw_parts(src as *const crate::mem::MaybeUninit<T>, count))
+        && ub_checks::can_write(core::ptr::slice_from_raw_parts_mut(dst, count))
+        && ub_checks::maybe_is_nonoverlapping(src as *const (), dst as *const (), size_of::<T>(), count))]
+    #[ensures(|_| check_copy_untyped(src, dst, count))]
+    #[kani::modifies(crate::ptr::slice_from_raw_parts(dst, count))]
+    #[allow(dead_code)]
+    unsafe fn copy_nonoverlapping_wrapper<T>(src: *const T, dst: *mut T, count: usize) {
+        unsafe { copy_nonoverlapping(src, dst, count) }
+    }
+
+    #[requires(!count.overflowing_mul(size_of::<T>()).1
+        && ub_checks::can_dereference(core::ptr::slice_from_raw_parts(src as *const crate::mem::MaybeUninit<T>, count))
+        && ub_checks::can_write(core::ptr::slice_from_raw_parts_mut(dst, count)))]
+    #[ensures(|_| check_copy_untyped(src, dst, count))]
+    #[kani::modifies(crate::ptr::slice_from_raw_parts(dst, count))]
+    #[allow(dead_code)]
+    unsafe fn copy_wrapper<T>(src: *const T, dst: *mut T, count: usize) {
+        unsafe { copy(src, dst, count) }
+    }
+
+    #[requires(!count.overflowing_mul(size_of::<T>()).1
+        && ub_checks::can_write(core::ptr::slice_from_raw_parts_mut(dst, count)))]
+    #[requires(ub_checks::maybe_is_aligned_and_not_null(dst as *const (), align_of::<T>(), T::IS_ZST || count == 0))]
+    #[ensures(|_| ub_checks::can_dereference(crate::ptr::slice_from_raw_parts(dst as *const u8, count * size_of::<T>())))]
+    #[kani::modifies(crate::ptr::slice_from_raw_parts(dst, count))]
+    #[allow(dead_code)]
+    unsafe fn write_bytes_wrapper<T>(dst: *mut T, val: u8, count: usize) {
+        unsafe { write_bytes(dst, val, count) }
+    }
+
+    #[kani::proof_for_contract(copy_wrapper)]
+    fn check_copy() {
+        run_with_arbitrary_ptrs::<char>(|src, dst| {
+            let count: usize = kani::any();
+            // Witness a valid overlap. The same overflow, `can_dereference`, and `can_write`
+            // conditions guard the contract call.
+            let sz = core::mem::size_of::<char>();
+            let s = src as usize;
+            let d = dst as usize;
+            let requires_hold = !count.overflowing_mul(sz).1
+                && ub_checks::can_dereference(core::ptr::slice_from_raw_parts(
+                    src as *const MaybeUninit<char>,
+                    count,
+                ))
+                && ub_checks::can_write(core::ptr::slice_from_raw_parts_mut(dst, count));
+            let overlap = count > 0
+                && s < d.wrapping_add(count.wrapping_mul(sz))
+                && d < s.wrapping_add(count.wrapping_mul(sz));
+            kani::cover(
+                requires_hold && overlap,
+                "copy: contract-admissible overlapping src/dst (count>0) is reachable",
+            );
+            // Witness valid overlap with a source not fully initialized as `char`.
+            // This makes the `check_copy_untyped` initialization oracle non-trivial.
+            kani::cover(
+                requires_hold && overlap && !ub_checks::can_dereference(src as *const char),
+                "copy: overlapping call with a non-fully-initialized source is reachable",
+            );
+            unsafe { copy_wrapper(src, dst, count) }
+        });
+    }
+
+    #[kani::proof_for_contract(copy_nonoverlapping_wrapper)]
+    fn check_copy_nonoverlapping() {
+        // `ArbitraryPointer` calls `copy_nonoverlapping`, which this contract check forbids.
+        let gen_any_ptr = |buf: &mut [MaybeUninit<char>; 100]| -> *mut char {
+            let base = buf.as_mut_ptr() as *mut u8;
+            base.wrapping_add(kani::any_where(|offset: &usize| *offset < 400)) as *mut char
+        };
+        let mut buffer1 = [MaybeUninit::<char>::uninit(); 100];
+        for i in 0..100 {
+            if kani::any() {
+                buffer1[i] = MaybeUninit::new(kani::any());
+            }
+        }
+        let mut buffer2 = [MaybeUninit::<char>::uninit(); 100];
+        let src = gen_any_ptr(&mut buffer1);
+        let dst = if kani::any() { gen_any_ptr(&mut buffer2) } else { gen_any_ptr(&mut buffer1) };
+        unsafe { copy_nonoverlapping_wrapper(src, dst, kani::any()) }
+    }
+
+    // kani#3345 requires a wrapper to contract `transmute_unchecked`.
     #[requires(crate::mem::size_of::<T>() == crate::mem::size_of::<U>())] //T and U have same size (transmute_unchecked does not guarantee this)
     #[requires(ub_checks::can_dereference(&input as *const T as *const U))] //output can be deref'd as value of type U
     #[allow(dead_code)]
@@ -3534,7 +3626,7 @@ mod verify {
         unsafe { transmute_unchecked(input) }
     }
 
-    //generates harness that transmutes arbitrary values of input type to output type
+    // Generate harnesses for arbitrary input values.
     macro_rules! proof_of_contract_for_transmute_unchecked {
         ($harness:ident, $src:ty, $dst:ty) => {
             #[kani::proof_for_contract(transmute_unchecked_wrapper)]
@@ -3545,16 +3637,16 @@ mod verify {
         };
     }
 
-    //We check the contract for all combinations of primitives
-    //transmute between 1-byte primitives
+    // Check all primitive combinations.
+    // One-byte primitives.
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_i8_to_u8, i8, u8);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_u8_to_i8, u8, i8);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_bool_to_i8, bool, i8);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_bool_to_u8, bool, u8);
-    //transmute between 2-byte primitives
+    // Two-byte primitives.
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_i16_to_u16, i16, u16);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_u16_to_i16, u16, i16);
-    //transmute between 4-byte primitives
+    // Four-byte primitives.
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_i32_to_u32, i32, u32);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_i32_to_f32, i32, f32);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_u32_to_i32, u32, i32);
@@ -3564,28 +3656,25 @@ mod verify {
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_char_to_f32, char, f32);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_f32_to_i32, f32, i32);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_f32_to_u32, f32, u32);
-    //transmute between 8-byte primitives
+    // Eight-byte primitives.
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_i64_to_u64, i64, u64);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_i64_to_f64, i64, f64);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_u64_to_i64, u64, i64);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_u64_to_f64, u64, f64);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_f64_to_i64, f64, i64);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_f64_to_u64, f64, u64);
-    //transmute between 16-byte primitives
+    // Sixteen-byte primitives.
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_i128_to_u128, i128, u128);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_u128_to_i128, u128, i128);
-    //transmute to type with potentially invalid bit patterns
+    // Outputs with invalid bit patterns.
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_i8_to_bool, i8, bool);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_u8_to_bool, u8, bool);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_i32_to_char, i32, char);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_u32_to_char, u32, char);
     proof_of_contract_for_transmute_unchecked!(transmute_unchecked_f32_to_char, f32, char);
 
-    //The follow are harnesses that check our function contract (specifically the weakness/strength
-    //of our generic validity precondition)
-    //In particular, should_succeed harnesses check that type-specific validity preconditions imply our generic precondition
-    //should_fail harnesses check that when we assume the negation of a type-specific validity
-    //precondition, the harness should trigger at least one failure
+    // Check the generic validity precondition.
+    // `should_succeed` checks that type rules imply it. `should_fail` negates those rules.
 
     #[kani::proof]
     #[kani::stub_verified(transmute_unchecked_wrapper)]
@@ -3666,12 +3755,9 @@ mod verify {
         let dst: bool = unsafe { transmute_unchecked_wrapper(src) };
     }
 
-    //The following harnesses do the same as above, but for compound types
-    //Since the goal is just to show that the generic precondition can work
-    //with compound types, we keep the examples of compound types simple, rather
-    //than attempting to enumerate them.
+    // Check simple compound types without enumerating them.
 
-    //This is 2-bytes large
+    // Two bytes.
     #[cfg_attr(kani, derive(kani::Arbitrary))]
     #[cfg_attr(kani, derive(PartialEq, Debug))]
     #[derive(Clone, Copy)]
@@ -3726,7 +3812,7 @@ mod verify {
         let dst: [bool; 2] = unsafe { transmute_unchecked_wrapper(src) };
     }
 
-    //generates should_succeed harnesses when the output type has no possible invalid values, like ints
+    // Generate `should_succeed` harnesses for always-valid output types.
     macro_rules! should_succeed_no_validity_reqs {
         ($harness:ident, $src:ty, $dst:ty) => {
             #[kani::proof]
@@ -3738,16 +3824,16 @@ mod verify {
         };
     }
 
-    //call the above macro for all combinations of primitives where the output value cannot be invalid
-    //transmute between 1-byte primitives
+    // Check primitive combinations with always-valid outputs.
+    // One-byte primitives.
     should_succeed_no_validity_reqs!(should_succeed_i8_to_u8, i8, u8);
     should_succeed_no_validity_reqs!(should_succeed_u8_to_i8, u8, i8);
     should_succeed_no_validity_reqs!(should_succeed_bool_to_i8, bool, i8);
     should_succeed_no_validity_reqs!(should_succeed_bool_to_u8, bool, u8);
-    //transmute between 2-byte primitives
+    // Two-byte primitives.
     should_succeed_no_validity_reqs!(should_succeed_i16_to_u16, i16, u16);
     should_succeed_no_validity_reqs!(should_succeed_u16_to_i16, u16, i16);
-    //transmute between 4-byte primitives
+    // Four-byte primitives.
     should_succeed_no_validity_reqs!(should_succeed_i32_to_u32, i32, u32);
     should_succeed_no_validity_reqs!(should_succeed_i32_to_f32, i32, f32);
     should_succeed_no_validity_reqs!(should_succeed_u32_to_i32, u32, i32);
@@ -3757,22 +3843,19 @@ mod verify {
     should_succeed_no_validity_reqs!(should_succeed_char_to_f32, char, f32);
     should_succeed_no_validity_reqs!(should_succeed_f32_to_i32, f32, i32);
     should_succeed_no_validity_reqs!(should_succeed_f32_to_u32, f32, u32);
-    //transmute between 8-byte primitives
+    // Eight-byte primitives.
     should_succeed_no_validity_reqs!(should_succeed_i64_to_u64, i64, u64);
     should_succeed_no_validity_reqs!(should_succeed_i64_to_f64, i64, f64);
     should_succeed_no_validity_reqs!(should_succeed_u64_to_i64, u64, i64);
     should_succeed_no_validity_reqs!(should_succeed_u64_to_f64, u64, f64);
     should_succeed_no_validity_reqs!(should_succeed_f64_to_i64, f64, i64);
     should_succeed_no_validity_reqs!(should_succeed_f64_to_u64, f64, u64);
-    //transmute between 16-byte primitives
+    // Sixteen-byte primitives.
     should_succeed_no_validity_reqs!(should_succeed_i128_to_u128, i128, u128);
     should_succeed_no_validity_reqs!(should_succeed_u128_to_i128, u128, i128);
 
-    //Note: the following harness fails when it in theory should not
-    //The problem is that ub_checks::can_dereference(), used in a validity precondition
-    //for transmute_unchecked_wrapper, doesn't catch references that refer to invalid values.
-    //Thus, this harness transmutes u8's to invalid bool values
-    //Maybe we can augment can_dereference() to handle this
+    // This fails because `ub_checks::can_dereference()` accepts references to invalid values.
+    // Extend it to reject invalid `bool` values produced from `u8`.
     /*
     #[kani::proof_for_contract(transmute_unchecked_wrapper)]
     fn transmute_unchecked_refs() {
@@ -3783,7 +3866,7 @@ mod verify {
         assert!(*int_ref2 == 0 || *int_ref2 == 1);
     }*/
 
-    //tests that transmute works correctly when transmuting something with zero size
+    // Check a zero-sized transmute.
     #[kani::proof_for_contract(transmute_unchecked_wrapper)]
     fn transmute_zero_size() {
         let empty_arr: [u8; 0] = [];
@@ -3791,9 +3874,7 @@ mod verify {
         assert!(unit_val == ());
     }
 
-    //generates harness that transmuted (unchecked) values, and casts them back to the original type
-    //i.e. (src -> dest) then (dest -> src)
-    //we then assert that the resulting value is equal to the initial value
+    // Generate unchecked round-trip harnesses.
     macro_rules! transmute_unchecked_two_ways {
         ($harness:ident, $src:ty, $dst:ty) => {
             #[kani::proof]
@@ -3807,9 +3888,7 @@ mod verify {
         };
     }
 
-    //generates 2-way harnesses again, but handles the [float => X => float] cases
-    //This is because kani::any can generate NaN floats, so we treat those
-    //separately rather than testing for equality like any other value
+    // Handle float round trips separately because `kani::any` can produce NaN.
     macro_rules! transmute_unchecked_two_ways_from_float {
         ($harness:ident, $src:ty, $dst:ty) => {
             #[kani::proof]
@@ -3827,18 +3906,18 @@ mod verify {
         };
     }
 
-    //The following invoke transmute_unchecked_two_ways for all the main primitives
-    //transmute 2-ways between 1-byte primitives
+    // Run unchecked round trips for the main primitives.
+    // One-byte primitives.
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_i8_to_u8, i8, u8);
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_i8_to_bool, i8, bool);
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_u8_to_i8, u8, i8);
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_u8_to_bool, u8, bool);
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_bool_to_i8, bool, i8);
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_bool_to_u8, bool, u8);
-    //transmute 2-ways between 2-byte primitives
+    // Two-byte primitives.
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_i16_to_u16, i16, u16);
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_u16_to_i16, u16, i16);
-    //transmute 2-ways between 4-byte primitives
+    // Four-byte primitives.
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_i32_to_u32, i32, u32);
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_i32_to_f32, i32, f32);
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_i32_to_char, i32, char);
@@ -3851,21 +3930,19 @@ mod verify {
     transmute_unchecked_two_ways_from_float!(transmute_unchecked_2ways_f32_to_i32, f32, i32);
     transmute_unchecked_two_ways_from_float!(transmute_unchecked_2ways_f32_to_u32, f32, u32);
     transmute_unchecked_two_ways_from_float!(transmute_unchecked_2ways_f32_to_char, f32, char);
-    //transmute 2-ways between 8-byte primitives
+    // Eight-byte primitives.
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_i64_to_u64, i64, u64);
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_i64_to_f64, i64, f64);
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_u64_to_i64, u64, i64);
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_u64_to_f64, u64, f64);
     transmute_unchecked_two_ways_from_float!(transmute_unchecked_2ways_f64_to_i64, f64, i64);
     transmute_unchecked_two_ways_from_float!(transmute_unchecked_2ways_f64_to_u64, f64, u64);
-    //transmute 2-ways between 16-byte primitives
+    // Sixteen-byte primitives.
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_i128_to_u128, i128, u128);
     transmute_unchecked_two_ways!(transmute_unchecked_2ways_u128_to_i128, u128, i128);
 
-    //Tests that transmuting (unchecked) a ptr does not mutate the stored address
-    //Note: the types being pointed to are intentionally small to avoid alignment issues
-    //The types are otherwise arbitrary -- the point of these harnesses is just to test
-    //that the value passed to transmute_unchecked (i.e., an address) is not mutated
+    // Check that unchecked pointer transmute preserves the address.
+    // Small pointees avoid alignment issues.
     #[kani::proof]
     fn check_transmute_unchecked_ptr_address() {
         let mut generator = PointerGenerator::<10000>::new();
@@ -3874,7 +3951,7 @@ mod verify {
         assert_eq!(arb_ptr as *const bool, arb_ptr_2 as *const u8 as *const bool);
     }
 
-    //Tests that transmuting (unchecked) a ref does not mutate the stored address
+    // Check that unchecked reference transmute preserves the address.
     #[kani::proof]
     fn check_transmute_unchecked_ref_address() {
         let mut generator = PointerGenerator::<10000>::new();
@@ -3884,24 +3961,21 @@ mod verify {
         assert_eq!(arb_ref as *const bool, arb_ref_2 as *const u8 as *const bool);
     }
 
-    //Tests that transmuting (unchecked) a slice does not mutate the slice metadata (address and length)
-    //Here, both the address and length of the slices are non-deterministic
+    // Check that unchecked slice transmute preserves an arbitrary address and length.
     #[kani::proof]
     fn check_transmute_unchecked_slice_metadata() {
         const MAX_SIZE: usize = 32;
         let mut generator = PointerGenerator::<10000>::new();
         let arb_arr_ptr: *const [bool; MAX_SIZE] = generator.any_in_bounds().ptr;
         let arb_slice = kani::slice::any_slice_of_array(unsafe { &*(arb_arr_ptr) });
-        //The following prevents taking redundant slices:
+        // Exclude redundant subslices.
         kani::assume(arb_slice.as_ptr() == arb_arr_ptr as *const bool);
         let arb_slice_2: &[u8] = unsafe { transmute_unchecked(arb_slice) };
         assert_eq!(arb_slice.as_ptr(), arb_slice_2.as_ptr() as *const bool);
         assert_eq!(arb_slice.len(), arb_slice_2.len());
     }
 
-    //generates harness that transmutes values, and casts them back to the original type
-    //i.e. (src -> dest) then (dest -> src)
-    //we then assert that the resulting value is equal to the initial value
+    // Generate checked round-trip harnesses.
     macro_rules! transmute_two_ways {
         ($harness:ident, $src:ty, $dst:ty) => {
             #[kani::proof]
@@ -3915,9 +3989,7 @@ mod verify {
         };
     }
 
-    //generates 2-way harnesses again, but handles the [float => X => float] cases
-    //This is because kani::any can generate NaN floats, so we treat those
-    //separately rather than testing for equality like any other value
+    // Handle float round trips separately because `kani::any` can produce NaN.
     macro_rules! transmute_two_ways_from_float {
         ($harness:ident, $src:ty, $dst:ty) => {
             #[kani::proof]
@@ -3935,18 +4007,18 @@ mod verify {
         };
     }
 
-    //The following invoke transmute_two_ways for all the main primitives
-    //transmute 2-ways between 1-byte primitives
+    // Run checked round trips for the main primitives.
+    // One-byte primitives.
     transmute_two_ways!(transmute_2ways_i8_to_u8, i8, u8);
     transmute_two_ways!(transmute_2ways_i8_to_bool, i8, bool);
     transmute_two_ways!(transmute_2ways_u8_to_i8, u8, i8);
     transmute_two_ways!(transmute_2ways_u8_to_bool, u8, bool);
     transmute_two_ways!(transmute_2ways_bool_to_i8, bool, i8);
     transmute_two_ways!(transmute_2ways_bool_to_u8, bool, u8);
-    //transmute 2-ways between 2-byte primitives
+    // Two-byte primitives.
     transmute_two_ways!(transmute_2ways_i16_to_u16, i16, u16);
     transmute_two_ways!(transmute_2ways_u16_to_i16, u16, i16);
-    //transmute 2-ways between 4-byte primitives
+    // Four-byte primitives.
     transmute_two_ways!(transmute_2ways_i32_to_u32, i32, u32);
     transmute_two_ways!(transmute_2ways_i32_to_f32, i32, f32);
     transmute_two_ways!(transmute_2ways_i32_to_char, i32, char);
@@ -3959,21 +4031,19 @@ mod verify {
     transmute_two_ways_from_float!(transmute_2ways_f32_to_i32, f32, i32);
     transmute_two_ways_from_float!(transmute_2ways_f32_to_u32, f32, u32);
     transmute_two_ways_from_float!(transmute_2ways_f32_to_char, f32, char);
-    //transmute 2-ways between 8-byte primitives
+    // Eight-byte primitives.
     transmute_two_ways!(transmute_2ways_i64_to_u64, i64, u64);
     transmute_two_ways!(transmute_2ways_i64_to_f64, i64, f64);
     transmute_two_ways!(transmute_2ways_u64_to_i64, u64, i64);
     transmute_two_ways!(transmute_2ways_u64_to_f64, u64, f64);
     transmute_two_ways_from_float!(transmute_2ways_f64_to_i64, f64, i64);
     transmute_two_ways_from_float!(transmute_2ways_f64_to_u64, f64, u64);
-    //transmute 2-ways between 16-byte primitives
+    // Sixteen-byte primitives.
     transmute_two_ways!(transmute_2ways_i128_to_u128, i128, u128);
     transmute_two_ways!(transmute_2ways_u128_to_i128, u128, i128);
 
-    //Tests that transmuting a ptr does not mutate the stored address
-    //Note: the types being pointed to are intentionally small to avoid alignment issues
-    //The types are otherwise arbitrary -- the point of these harnesses is just to test
-    //that the value passed to transmute (i.e., an address) is not mutated
+    // Check that pointer transmute preserves the address.
+    // Small pointees avoid alignment issues.
     #[kani::proof]
     fn check_transmute_ptr_address() {
         let mut generator = PointerGenerator::<10000>::new();
@@ -3982,7 +4052,7 @@ mod verify {
         assert_eq!(arb_ptr as *const bool, arb_ptr_2 as *const u8 as *const bool);
     }
 
-    //Tests that transmuting a ref does not mutate the stored address
+    // Check that reference transmute preserves the address.
     #[kani::proof]
     fn check_transmute_ref_address() {
         let mut generator = PointerGenerator::<10000>::new();
@@ -3992,25 +4062,21 @@ mod verify {
         assert_eq!(arb_ref as *const bool, arb_ref_2 as *const u8 as *const bool);
     }
 
-    //Tests that transmuting a slice does not mutate the slice metadata (address and length)
-    //Here, both the address and length of the slices are non-deterministic
+    // Check that slice transmute preserves an arbitrary address and length.
     #[kani::proof]
     fn check_transmute_slice_metadata() {
         const MAX_SIZE: usize = 32;
         let mut generator = PointerGenerator::<10000>::new();
         let arb_arr_ptr: *const [bool; MAX_SIZE] = generator.any_in_bounds().ptr;
         let arb_slice = kani::slice::any_slice_of_array(unsafe { &*(arb_arr_ptr) });
-        //The following prevents taking redundant slices:
+        // Exclude redundant subslices.
         kani::assume(arb_slice.as_ptr() == arb_arr_ptr as *const bool);
         let arb_slice_2: &[u8] = unsafe { transmute(arb_slice) };
         assert_eq!(arb_slice.as_ptr(), arb_slice_2.as_ptr() as *const bool);
         assert_eq!(arb_slice.len(), arb_slice_2.len());
     }
 
-    //tests that transmutes between compound data structures (currently structs,
-    //arrays, and tuples) do not mutate the underlying data.
-    //To keep things simple, we limit these structures to containing two of whatever
-    //the input type is, since that's the smallest non-trivial amount.
+    // Check two-element structs, arrays, and tuples.
     macro_rules! gen_compound_harnesses {
         ($mod_name:ident, $base_type:ty) => {
             mod $mod_name {
@@ -4024,7 +4090,7 @@ mod verify {
                     f2: $base_type,
                 }
 
-                //transmute harnesses
+                // Checked harnesses.
                 transmute_two_ways!(
                     transmute_2ways_struct_to_arr,
                     generated_struct,
@@ -4055,7 +4121,7 @@ mod verify {
                     ($base_type, $base_type),
                     [$base_type; 2]
                 );
-                //transmute_unchecked harnesses
+                // Unchecked harnesses.
                 transmute_unchecked_two_ways!(
                     transmute_unchecked_2ways_struct_to_arr,
                     generated_struct,
@@ -4098,8 +4164,7 @@ mod verify {
         f2: u8,
     }
 
-    //generate compound harnesses for main primitive types, as well as with
-    //some compound types (to obtain nested compound types)
+    // Generate primitive and nested compound harnesses.
     gen_compound_harnesses!(u8_mod, u8);
     gen_compound_harnesses!(u16_mod, u16);
     gen_compound_harnesses!(u32_mod, u32);
@@ -4116,16 +4181,941 @@ mod verify {
     gen_compound_harnesses!(arr_mod, [u8; 2]);
     gen_compound_harnesses!(struct_mod, u8_struct);
 
-    // FIXME: Enable this harness once <https://github.com/model-checking/kani/issues/90> is fixed.
-    // Harness triggers a spurious failure when writing 0 bytes to an invalid memory location,
-    // which is a safe operation.
-    #[cfg(not(kani))]
-    #[kani::proof_for_contract(write_bytes)]
+    // Kani 0.67 fixes kani#90. kani#3325 puts this contract on `write_bytes_wrapper`.
+    #[kani::proof_for_contract(write_bytes_wrapper)]
     fn check_write_bytes() {
         let mut generator = PointerGenerator::<100>::new();
         let ArbitraryPointer { ptr, status, .. } = generator.any_alloc_status::<char>();
         kani::assume(supported_status(status));
-        unsafe { write_bytes(ptr, kani::any(), kani::any()) };
+        let count: usize = kani::any();
+        // Witness the kani#90 case: a valid zero-count write to `Null` or `OutOfBounds`.
+        // Zero makes the overflow, `can_write`, and alignment requirements hold.
+        kani::cover(
+            count == 0 && status != AllocationStatus::InBounds,
+            "write_bytes: 0-count write to a non-dereferenceable dst is reachable (kani#90 trigger)",
+        );
+        unsafe { write_bytes_wrapper(ptr, kani::any(), count) };
+    }
+
+    // Independently check each byte written by `write_bytes`. This rejects a no-op.
+    #[kani::proof]
+    #[kani::unwind(5)]
+    fn check_write_bytes_sets_value() {
+        let mut buf = [MaybeUninit::<u8>::uninit(); 4];
+        let ptr = buf.as_mut_ptr() as *mut u8;
+        let val: u8 = kani::any();
+        let count: usize = kani::any_where(|c: &usize| *c <= 4);
+        unsafe { write_bytes(ptr, val, count) };
+        for i in 0..count {
+            assert_eq!(unsafe { *ptr.add(i) }, val);
+        }
+        kani::cover(count > 0, "write_bytes value check: nonzero count reached");
+    }
+
+    // kani#3325 and kani#3345 reject contracts on no-body intrinsics.
+    // Thin wrappers carry the same requirements and independent oracles as the plain proofs.
+
+    // `arith_offset` has no safety precondition. See `ptr/const_ptr.rs`.
+    // `check_arith_offset_unconditional_safety` checks all offsets without dereferencing them.
+    // Probe only: the bounded wrapper checks behavior in Kani's pointer model, not the intrinsic's
+    // general contract. CBMC preserves the address identity only within the fixture object.
+    #[requires(offset >= 0 && offset <= 8)]
+    #[ensures(|result| *result as usize == (dst as usize).wrapping_add(offset as usize))]
+    #[allow(dead_code)]
+    unsafe fn arith_offset_wrapper(dst: *const u8, offset: isize) -> *const u8 {
+        unsafe { arith_offset(dst, offset) }
+    }
+
+    #[kani::proof_for_contract(arith_offset_wrapper)]
+    pub fn check_arith_offset_wrapper_contract() {
+        let arr: [u8; 8] = kani::any();
+        let base = arr.as_ptr();
+        // The bound scopes only the pointer-model probe, not safety.
+        let offset: isize = kani::any();
+        let _ = unsafe { arith_offset_wrapper(base, offset) };
+    }
+
+    // Check unconditional `arith_offset` safety for every `offset: isize`.
+    // The cover witnesses a non-null result.
+    #[kani::proof]
+    pub fn check_arith_offset_unconditional_safety() {
+        let arr: [u8; 8] = kani::any();
+        let base = arr.as_ptr();
+        let offset: isize = kani::any();
+        let r = unsafe { arith_offset(base, offset) };
+        kani::cover(!r.is_null(), "arith_offset result observed with unbounded offset (no UB)");
+    }
+
+    // Match `ptr_offset_from` in `ptr/const_ptr.rs`: no overflow, whole elements, same allocation.
+    #[requires(
+        (ptr as isize).checked_sub(base as isize).is_some()
+            && (ptr as isize - base as isize) % (size_of::<u8>() as isize) == 0
+            && (ptr as isize == base as isize || ub_checks::same_allocation(ptr, base))
+    )]
+    #[ensures(|result| *result == (ptr as isize - base as isize) / (size_of::<u8>() as isize))]
+    #[allow(dead_code)]
+    unsafe fn ptr_offset_from_wrapper(ptr: *const u8, base: *const u8) -> isize {
+        unsafe { ptr_offset_from(ptr, base) }
+    }
+
+    #[kani::proof_for_contract(ptr_offset_from_wrapper)]
+    pub fn check_ptr_offset_from_wrapper_contract() {
+        let arr_a: [u8; 8] = kani::any();
+        let arr_b: [u8; 8] = kani::any();
+        let base_a = arr_a.as_ptr();
+        let base_b = arr_b.as_ptr();
+        let i: usize = kani::any();
+        let j: usize = kani::any();
+        kani::assume(i <= 8 && j <= 8);
+        // Reach both same- and cross-allocation pairs. `#[requires]` filters them.
+        let pi_from_a: bool = kani::any();
+        let pj_from_a: bool = kani::any();
+        let pi = if pi_from_a { unsafe { base_a.add(i) } } else { unsafe { base_b.add(i) } };
+        let pj = if pj_from_a { unsafe { base_a.add(j) } } else { unsafe { base_b.add(j) } };
+        let _ = unsafe { ptr_offset_from_wrapper(pi, pj) };
+    }
+
+    // `ptr_offset_from_unsigned` also requires `ptr >= base`. See `ptr/const_ptr.rs`.
+    #[requires(
+        (ptr as isize).checked_sub(base as isize).is_some()
+            && (ptr as isize - base as isize) % (size_of::<u8>() as isize) == 0
+            && (ptr as isize == base as isize || ub_checks::same_allocation(ptr, base))
+            && ptr as usize >= base as usize
+    )]
+    #[ensures(|result| *result == (ptr as usize - base as usize) / size_of::<u8>())]
+    #[allow(dead_code)]
+    unsafe fn ptr_offset_from_unsigned_wrapper(ptr: *const u8, base: *const u8) -> usize {
+        unsafe { ptr_offset_from_unsigned(ptr, base) }
+    }
+
+    #[kani::proof_for_contract(ptr_offset_from_unsigned_wrapper)]
+    pub fn check_ptr_offset_from_unsigned_wrapper_contract() {
+        let arr_a: [u8; 8] = kani::any();
+        let arr_b: [u8; 8] = kani::any();
+        let base_a = arr_a.as_ptr();
+        let base_b = arr_b.as_ptr();
+        let i: usize = kani::any();
+        let j: usize = kani::any();
+        kani::assume(i <= 8 && j <= 8);
+        let pi_from_a: bool = kani::any();
+        let pj_from_a: bool = kani::any();
+        let pi = if pi_from_a { unsafe { base_a.add(i) } } else { unsafe { base_b.add(i) } };
+        let pj = if pj_from_a { unsafe { base_a.add(j) } } else { unsafe { base_b.add(j) } };
+        let _ = unsafe { ptr_offset_from_unsigned_wrapper(pi, pj) };
+    }
+
+    // `read_via_copy` requires a projection-free local accepted by `can_dereference`.
+    // A plain load is the independent oracle.
+    #[requires(ub_checks::can_dereference(ptr))]
+    #[ensures(|result| *result == unsafe { *ptr })]
+    #[allow(dead_code)]
+    unsafe fn read_via_copy_wrapper(ptr: *const u32) -> u32 {
+        unsafe { read_via_copy(ptr) }
+    }
+
+    #[kani::proof_for_contract(read_via_copy_wrapper)]
+    pub fn check_read_via_copy_wrapper_contract() {
+        let val: u32 = kani::any();
+        let local = val;
+        let ptr: *const u32 = &local;
+        let _ = unsafe { read_via_copy_wrapper(ptr) };
+    }
+
+    // `write_via_move` requires `can_write`. A plain dereference is the independent oracle.
+    #[cfg_attr(kani, kani::modifies(ptr))]
+    #[requires(ub_checks::can_write(ptr))]
+    #[ensures(|_| unsafe { *ptr } == value)]
+    #[allow(dead_code)]
+    unsafe fn write_via_move_wrapper(ptr: *mut u32, value: u32) {
+        unsafe { write_via_move(ptr, value) }
+    }
+
+    #[kani::proof_for_contract(write_via_move_wrapper)]
+    pub fn check_write_via_move_wrapper_contract() {
+        let val: u32 = kani::any();
+        let mut local: u32 = kani::any();
+        let ptr: *mut u32 = &mut local;
+        unsafe { write_via_move_wrapper(ptr, val) };
+    }
+
+    // `compare_bytes` requires both regions to be readable for `bytes` bytes.
+    // An independent loop checks every symbolic `bytes` value.
+    // `COMPARE_BYTES_CAP` bounds only the harness, not the contract.
+    const COMPARE_BYTES_CAP: usize = 4;
+    #[requires(ub_checks::can_dereference(crate::ptr::slice_from_raw_parts(left, bytes))
+        && ub_checks::can_dereference(crate::ptr::slice_from_raw_parts(right, bytes)))]
+    #[ensures(|result| {
+        // Independently compare the first `bytes` bytes.
+        let mut idx = 0;
+        let mut verdict: i32 = 0;
+        let mut decided = false;
+        while idx < bytes {
+            let lb = unsafe { *left.add(idx) };
+            let rb = unsafe { *right.add(idx) };
+            if !decided && lb != rb {
+                verdict = if lb < rb { -1 } else { 1 };
+                decided = true;
+            }
+            idx += 1;
+        }
+        if decided {
+            (verdict < 0 && *result < 0) || (verdict > 0 && *result > 0)
+        } else {
+            *result == 0
+        }
+    })]
+    #[allow(dead_code)]
+    unsafe fn compare_bytes_wrapper(left: *const u8, right: *const u8, bytes: usize) -> i32 {
+        unsafe { compare_bytes(left, right, bytes) }
+    }
+
+    #[kani::unwind(5)] // CAP (4) + 1
+    #[kani::proof_for_contract(compare_bytes_wrapper)]
+    pub fn check_compare_bytes_wrapper_contract() {
+        const CAP: usize = COMPARE_BYTES_CAP;
+        let left: [u8; CAP] = kani::any();
+        let right: [u8; CAP] = kani::any();
+        let bytes: usize = kani::any();
+        kani::assume(bytes <= CAP);
+        let _ = unsafe { compare_bytes_wrapper(left.as_ptr(), right.as_ptr(), bytes) };
+    }
+
+    // For sized `T`, `size_of_val` reads no memory and accepts any pointer.
+    // `size_of::<T>()` is the independent oracle. The harness covers null, dangling, and raw cases.
+    // Residual: this wrapper excludes `?Sized`, whose metadata must be valid. Later wrappers cover
+    // trait objects and slices.
+    #[ensures(|result| *result == core::mem::size_of::<T>())]
+    #[allow(dead_code)]
+    unsafe fn size_of_val_wrapper<T>(ptr: *const T) -> usize {
+        unsafe { size_of_val(ptr) }
+    }
+
+    #[kani::proof_for_contract(size_of_val_wrapper)]
+    pub fn check_size_of_val_wrapper_contract() {
+        let val: u32 = kani::any();
+        let raw_addr: usize = kani::any();
+        let case: u8 = kani::any();
+        kani::assume(case < 4);
+        let ptr: *const u32 = match case {
+            0 => core::ptr::null(),
+            1 => core::ptr::NonNull::<u32>::dangling().as_ptr() as *const u32,
+            2 => raw_addr as *const u32,
+            _ => &val as *const u32,
+        };
+        kani::cover(case == 0, "size_of_val: null pointer case reached");
+        kani::cover(case == 1, "size_of_val: dangling pointer case reached");
+        kani::cover(case == 2, "size_of_val: nondet-address pointer case reached");
+        let _ = unsafe { size_of_val_wrapper::<u32>(ptr) };
+    }
+
+    // `size_of_val` for `?Sized` uses metadata. These wrappers establish its documented conditions.
+    // The trait-object wrapper creates the vtable by unsizing. `size_of::<T>()` is its oracle.
+    // The slice wrapper requires initialized `len` metadata whose byte size fits in `isize`.
+    // Its oracle is `size_of::<T>() * len`; the ZST branch avoids division by zero.
+    // Residual: composite unsized tails are not instantiated. Kani models them, so this is only
+    // untested scope. Extern types are excluded because Kani's model panics on them.
+    #[ensures(|result| *result == core::mem::size_of::<T>())]
+    #[allow(dead_code)]
+    unsafe fn size_of_val_dyn_wrapper<T: core::fmt::Debug>(ptr: *const T) -> usize {
+        // The unsize coercion creates a valid vtable bound to `T`.
+        let dyn_ptr: *const dyn core::fmt::Debug = ptr;
+        unsafe { size_of_val(dyn_ptr) }
+    }
+
+    #[requires(
+        core::mem::size_of::<T>() == 0
+            || len <= (isize::MAX as usize) / core::mem::size_of::<T>()
+    )]
+    #[ensures(|result| *result == core::mem::size_of::<T>() * len)]
+    #[allow(dead_code)]
+    unsafe fn size_of_val_slice_wrapper<T>(ptr: *const T, len: usize) -> usize {
+        let slice_ptr: *const [T] = crate::ptr::slice_from_raw_parts(ptr, len);
+        unsafe { size_of_val(slice_ptr) }
+    }
+
+    #[kani::proof_for_contract(size_of_val_dyn_wrapper)]
+    pub fn check_size_of_val_dyn_wrapper_contract_u32() {
+        let val: u32 = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const u32 = if real { &val } else { addr as *const u32 };
+        kani::cover(!real, "size_of_val dyn u32: nondet-address pointer case reached");
+        let _ = unsafe { size_of_val_dyn_wrapper::<u32>(ptr) };
+    }
+
+    // Distinguish the size slot from alignment with an 8-byte, 1-aligned type.
+    #[kani::proof_for_contract(size_of_val_dyn_wrapper)]
+    pub fn check_size_of_val_dyn_wrapper_contract_arr_u8_8() {
+        let val: [u8; 8] = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const [u8; 8] = if real { &val } else { addr as *const [u8; 8] };
+        kani::cover(!real, "size_of_val dyn [u8; 8]: nondet-address pointer case reached");
+        let _ = unsafe { size_of_val_dyn_wrapper::<[u8; 8]>(ptr) };
+    }
+
+    // Add an independent `(size, align) = (16, 16)` case.
+    // Residual: only a composite unsized tail can exercise non-trivial alignment rounding.
+    #[kani::proof_for_contract(size_of_val_dyn_wrapper)]
+    pub fn check_size_of_val_dyn_wrapper_contract_over_aligned() {
+        let val = OverAligned16(kani::any());
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const OverAligned16 = if real { &val } else { addr as *const OverAligned16 };
+        kani::cover(!real, "size_of_val dyn OverAligned16: nondet-address case reached");
+        let _ = unsafe { size_of_val_dyn_wrapper::<OverAligned16>(ptr) };
+    }
+
+    #[kani::proof_for_contract(size_of_val_dyn_wrapper)]
+    pub fn check_size_of_val_dyn_wrapper_contract_zst() {
+        let val = VtableZst;
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const VtableZst = if real { &val } else { addr as *const VtableZst };
+        kani::cover(!real, "size_of_val dyn ZST: nondet-address pointer case reached");
+        let _ = unsafe { size_of_val_dyn_wrapper::<VtableZst>(ptr) };
+    }
+
+    // Check every contract-valid symbolic `len`. `size_of_val` reads only slice metadata.
+    #[kani::proof_for_contract(size_of_val_slice_wrapper)]
+    pub fn check_size_of_val_slice_wrapper_contract_u8() {
+        let val: [u8; 4] = kani::any();
+        let len: usize = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const u8 = if real { val.as_ptr() } else { addr as *const u8 };
+        kani::cover(len == 0, "size_of_val slice u8: zero-length case reached");
+        kani::cover(len > 1, "size_of_val slice u8: multi-element case reached");
+        let _ = unsafe { size_of_val_slice_wrapper::<u8>(ptr, len) };
+    }
+
+    #[kani::proof_for_contract(size_of_val_slice_wrapper)]
+    pub fn check_size_of_val_slice_wrapper_contract_u32() {
+        let val: [u32; 4] = kani::any();
+        let len: usize = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const u32 = if real { val.as_ptr() } else { addr as *const u32 };
+        kani::cover(len == 0, "size_of_val slice u32: zero-length case reached");
+        kani::cover(len > 1, "size_of_val slice u32: multi-element case reached");
+        let _ = unsafe { size_of_val_slice_wrapper::<u32>(ptr, len) };
+    }
+
+    // A 16-byte element reaches the `isize::MAX` bound earliest.
+    #[kani::proof_for_contract(size_of_val_slice_wrapper)]
+    pub fn check_size_of_val_slice_wrapper_contract_over_aligned() {
+        let val = OverAligned16(kani::any());
+        let len: usize = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const OverAligned16 = if real { &val } else { addr as *const OverAligned16 };
+        kani::cover(len == 0, "size_of_val slice OverAligned16: zero-length case reached");
+        kani::cover(len > 1, "size_of_val slice OverAligned16: multi-element case reached");
+        let _ = unsafe { size_of_val_slice_wrapper::<OverAligned16>(ptr, len) };
+    }
+
+    // Exercise the ZST branch for every `len`, including `usize::MAX`.
+    #[kani::proof_for_contract(size_of_val_slice_wrapper)]
+    pub fn check_size_of_val_slice_wrapper_contract_zst_elem() {
+        let val = VtableZst;
+        let len: usize = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const VtableZst = if real { &val } else { addr as *const VtableZst };
+        kani::cover(len == usize::MAX, "size_of_val slice ZST elem: usize::MAX length reached");
+        let _ = unsafe { size_of_val_slice_wrapper::<VtableZst>(ptr, len) };
+    }
+
+    // Check `volatile_load` and `volatile_store` by value-preserving round trips.
+    // Residual: `can_dereference` and `can_write` cover only Rust-backed allocations. Kani's
+    // pointer model cannot represent the documented external-memory MMIO case.
+    #[requires(ub_checks::can_dereference(src))]
+    #[ensures(|result| *result == unsafe { *src })]
+    #[allow(dead_code)]
+    unsafe fn volatile_load_wrapper(src: *const u32) -> u32 {
+        unsafe { volatile_load(src) }
+    }
+
+    #[kani::proof_for_contract(volatile_load_wrapper)]
+    pub fn check_volatile_load_wrapper_contract() {
+        let val: u32 = kani::any();
+        let local = val;
+        let ptr: *const u32 = &local;
+        let _ = unsafe { volatile_load_wrapper(ptr) };
+    }
+
+    #[cfg_attr(kani, kani::modifies(dst))]
+    #[requires(ub_checks::can_write(dst))]
+    #[ensures(|_| unsafe { *dst } == val)]
+    #[allow(dead_code)]
+    unsafe fn volatile_store_wrapper(dst: *mut u32, val: u32) {
+        unsafe { volatile_store(dst, val) }
+    }
+
+    #[kani::proof_for_contract(volatile_store_wrapper)]
+    pub fn check_volatile_store_wrapper_contract() {
+        let val: u32 = kani::any();
+        let mut local: u32 = kani::any();
+        let ptr: *mut u32 = &mut local;
+        unsafe { volatile_store_wrapper(ptr, val) };
+    }
+
+    // Monomorphic probe, not the general `vtable_size` or `vtable_align` contract.
+    // Raw `*const ()` erases the link between `T` and the vtable. `can_dereference` only proves
+    // that three `usize`s are readable. Each wrapper therefore checks one fixed `T` only.
+    // These probes keep the intrinsic's exact signature but are excluded from the verified count.
+    #[requires(ub_checks::can_dereference(ptr as *const [usize; 3]))]
+    #[ensures(|result| *result == core::mem::size_of::<T>())]
+    #[allow(dead_code)]
+    unsafe fn vtable_size_wrapper<T>(ptr: *const ()) -> usize {
+        unsafe { vtable_size(ptr) }
+    }
+
+    #[requires(ub_checks::can_dereference(ptr as *const [usize; 3]))]
+    #[ensures(|result| *result == core::mem::align_of::<T>())]
+    #[allow(dead_code)]
+    unsafe fn vtable_align_wrapper<T>(ptr: *const ()) -> usize {
+        unsafe { vtable_align(ptr) }
+    }
+
+    // Mirror private `DynMetadata::vtable_ptr`; the compiler guarantees this transmute layout.
+    // `dyn core::fmt::Debug` meets the renamed `PointeeSized` bound.
+    fn vtable_ptr_of<Dyn: core::fmt::Debug + ?Sized>(
+        meta: crate::ptr::DynMetadata<Dyn>,
+    ) -> *const () {
+        unsafe { crate::mem::transmute::<crate::ptr::DynMetadata<Dyn>, *const ()>(meta) }
+    }
+
+    #[kani::proof_for_contract(vtable_size_wrapper)]
+    pub fn check_vtable_size_wrapper_contract() {
+        let val: u32 = kani::any();
+        let debug_ref: &dyn core::fmt::Debug = &val;
+        let meta = crate::ptr::metadata(debug_ref as *const dyn core::fmt::Debug);
+        let vtable_ptr = vtable_ptr_of(meta);
+        let _ = unsafe { vtable_size_wrapper::<u32>(vtable_ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_align_wrapper)]
+    pub fn check_vtable_align_wrapper_contract() {
+        let val: u32 = kani::any();
+        let debug_ref: &dyn core::fmt::Debug = &val;
+        let meta = crate::ptr::metadata(debug_ref as *const dyn core::fmt::Debug);
+        let vtable_ptr = vtable_ptr_of(meta);
+        let _ = unsafe { vtable_align_wrapper::<u32>(vtable_ptr) };
+    }
+
+    // A second monomorphic probe uses `T = u64`; this is still not a generic proof.
+    #[kani::proof_for_contract(vtable_size_wrapper)]
+    pub fn check_vtable_size_wrapper_contract_u64() {
+        let val: u64 = kani::any();
+        let debug_ref: &dyn core::fmt::Debug = &val;
+        let meta = crate::ptr::metadata(debug_ref as *const dyn core::fmt::Debug);
+        let vtable_ptr = vtable_ptr_of(meta);
+        let _ = unsafe { vtable_size_wrapper::<u64>(vtable_ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_align_wrapper)]
+    pub fn check_vtable_align_wrapper_contract_u64() {
+        let val: u64 = kani::any();
+        let debug_ref: &dyn core::fmt::Debug = &val;
+        let meta = crate::ptr::metadata(debug_ref as *const dyn core::fmt::Debug);
+        let vtable_ptr = vtable_ptr_of(meta);
+        let _ = unsafe { vtable_align_wrapper::<u64>(vtable_ptr) };
+    }
+
+    // General `vtable_size` and `vtable_align` contracts.
+    // Taking `*const T` and unsizing inside the wrapper binds the vtable to `T`.
+    // Kani emits its `codegen_vtable`, so callers cannot substitute another type's vtable.
+    // The wrapper establishes the documented vtable precondition and needs no `#[requires]`.
+    // Residual: rustc's `layout_of` supplies both the vtable constant and `size_of::<T>()`.
+    // The proof still checks vtable selection, `Kani::CommonVTable` slot layout, and rustc's value
+    // against CBMC's independent `__CPROVER_OBJECT_SIZE` value.
+    // It cannot detect `layout_of` disagreeing with the final LLVM vtable.
+    // Residual: the wrappers use only `core::fmt::Debug`. Rustc fixes size, align, and drop as the
+    // first three slots for every trait, but this does not prove all traits.
+    // Keep the raw `*const ()` wrappers above as monomorphic probes of the intrinsic's exact form.
+    // Only these typed contracts count as general contracts.
+    #[ensures(|result| *result == core::mem::size_of::<T>())]
+    #[allow(dead_code)]
+    unsafe fn vtable_size_coerced_wrapper<T: core::fmt::Debug>(ptr: *const T) -> usize {
+        // The unsize coercion binds the vtable to `T`.
+        let dyn_ptr: *const dyn core::fmt::Debug = ptr;
+        let vtable_ptr = vtable_ptr_of(crate::ptr::metadata(dyn_ptr));
+        unsafe { vtable_size(vtable_ptr) }
+    }
+
+    #[ensures(|result| *result == core::mem::align_of::<T>())]
+    #[allow(dead_code)]
+    unsafe fn vtable_align_coerced_wrapper<T: core::fmt::Debug>(ptr: *const T) -> usize {
+        // The unsize coercion binds the vtable to `T`.
+        let dyn_ptr: *const dyn core::fmt::Debug = ptr;
+        let vtable_ptr = vtable_ptr_of(crate::ptr::metadata(dyn_ptr));
+        unsafe { vtable_align(vtable_ptr) }
+    }
+
+    // Trivial `Debug` impls avoid unused formatting code in the vtables.
+    struct VtableZst;
+    impl core::fmt::Debug for VtableZst {
+        fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            Ok(())
+        }
+    }
+
+    // Size 16, alignment 8.
+    #[repr(C)]
+    struct MixedAlign {
+        a: u8,
+        b: u64,
+    }
+    impl core::fmt::Debug for MixedAlign {
+        fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            Ok(())
+        }
+    }
+
+    // Size 16, alignment 16.
+    #[repr(align(16))]
+    struct OverAligned16(#[allow(dead_code)] u8);
+    impl core::fmt::Debug for OverAligned16 {
+        fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            Ok(())
+        }
+    }
+
+    #[kani::proof_for_contract(vtable_size_coerced_wrapper)]
+    pub fn check_vtable_size_coerced_wrapper_contract_u8() {
+        let val: u8 = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const u8 = if real { &val } else { addr as *const u8 };
+        kani::cover(!real, "vtable_size coerced u8: nondet-address pointer case reached");
+        let _ = unsafe { vtable_size_coerced_wrapper::<u8>(ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_align_coerced_wrapper)]
+    pub fn check_vtable_align_coerced_wrapper_contract_u8() {
+        let val: u8 = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const u8 = if real { &val } else { addr as *const u8 };
+        kani::cover(!real, "vtable_align coerced u8: nondet-address pointer case reached");
+        let _ = unsafe { vtable_align_coerced_wrapper::<u8>(ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_size_coerced_wrapper)]
+    pub fn check_vtable_size_coerced_wrapper_contract_u32() {
+        let val: u32 = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const u32 = if real { &val } else { addr as *const u32 };
+        kani::cover(!real, "vtable_size coerced u32: nondet-address pointer case reached");
+        let _ = unsafe { vtable_size_coerced_wrapper::<u32>(ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_align_coerced_wrapper)]
+    pub fn check_vtable_align_coerced_wrapper_contract_u32() {
+        let val: u32 = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const u32 = if real { &val } else { addr as *const u32 };
+        kani::cover(!real, "vtable_align coerced u32: nondet-address pointer case reached");
+        let _ = unsafe { vtable_align_coerced_wrapper::<u32>(ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_size_coerced_wrapper)]
+    pub fn check_vtable_size_coerced_wrapper_contract_u64() {
+        let val: u64 = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const u64 = if real { &val } else { addr as *const u64 };
+        kani::cover(!real, "vtable_size coerced u64: nondet-address pointer case reached");
+        let _ = unsafe { vtable_size_coerced_wrapper::<u64>(ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_align_coerced_wrapper)]
+    pub fn check_vtable_align_coerced_wrapper_contract_u64() {
+        let val: u64 = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const u64 = if real { &val } else { addr as *const u64 };
+        kani::cover(!real, "vtable_align coerced u64: nondet-address pointer case reached");
+        let _ = unsafe { vtable_align_coerced_wrapper::<u64>(ptr) };
+    }
+
+    // Size 8, alignment 1 rejects a `T = u32` monomorphic claim.
+    #[kani::proof_for_contract(vtable_size_coerced_wrapper)]
+    pub fn check_vtable_size_coerced_wrapper_contract_arr_u8_8() {
+        let val: [u8; 8] = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const [u8; 8] = if real { &val } else { addr as *const [u8; 8] };
+        kani::cover(!real, "vtable_size coerced [u8; 8]: nondet-address pointer case reached");
+        let _ = unsafe { vtable_size_coerced_wrapper::<[u8; 8]>(ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_align_coerced_wrapper)]
+    pub fn check_vtable_align_coerced_wrapper_contract_arr_u8_8() {
+        let val: [u8; 8] = kani::any();
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const [u8; 8] = if real { &val } else { addr as *const [u8; 8] };
+        kani::cover(!real, "vtable_align coerced [u8; 8]: nondet-address pointer case reached");
+        let _ = unsafe { vtable_align_coerced_wrapper::<[u8; 8]>(ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_size_coerced_wrapper)]
+    pub fn check_vtable_size_coerced_wrapper_contract_zst() {
+        let val = VtableZst;
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const VtableZst = if real { &val } else { addr as *const VtableZst };
+        kani::cover(!real, "vtable_size coerced ZST: nondet-address pointer case reached");
+        let _ = unsafe { vtable_size_coerced_wrapper::<VtableZst>(ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_align_coerced_wrapper)]
+    pub fn check_vtable_align_coerced_wrapper_contract_zst() {
+        let val = VtableZst;
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const VtableZst = if real { &val } else { addr as *const VtableZst };
+        kani::cover(!real, "vtable_align coerced ZST: nondet-address pointer case reached");
+        let _ = unsafe { vtable_align_coerced_wrapper::<VtableZst>(ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_size_coerced_wrapper)]
+    pub fn check_vtable_size_coerced_wrapper_contract_mixed_align() {
+        let val = MixedAlign { a: kani::any(), b: kani::any() };
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const MixedAlign = if real { &val } else { addr as *const MixedAlign };
+        kani::cover(!real, "vtable_size coerced MixedAlign: nondet-address pointer case reached");
+        let _ = unsafe { vtable_size_coerced_wrapper::<MixedAlign>(ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_align_coerced_wrapper)]
+    pub fn check_vtable_align_coerced_wrapper_contract_mixed_align() {
+        let val = MixedAlign { a: kani::any(), b: kani::any() };
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const MixedAlign = if real { &val } else { addr as *const MixedAlign };
+        kani::cover(!real, "vtable_align coerced MixedAlign: nondet-address pointer case reached");
+        let _ = unsafe { vtable_align_coerced_wrapper::<MixedAlign>(ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_size_coerced_wrapper)]
+    pub fn check_vtable_size_coerced_wrapper_contract_over_aligned() {
+        let val = OverAligned16(kani::any());
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const OverAligned16 = if real { &val } else { addr as *const OverAligned16 };
+        kani::cover(!real, "vtable_size coerced OverAligned16: nondet-address case reached");
+        let _ = unsafe { vtable_size_coerced_wrapper::<OverAligned16>(ptr) };
+    }
+
+    #[kani::proof_for_contract(vtable_align_coerced_wrapper)]
+    pub fn check_vtable_align_coerced_wrapper_contract_over_aligned() {
+        let val = OverAligned16(kani::any());
+        let addr: usize = kani::any();
+        let real: bool = kani::any();
+        let ptr: *const OverAligned16 = if real { &val } else { addr as *const OverAligned16 };
+        kani::cover(!real, "vtable_align coerced OverAligned16: nondet-address case reached");
+        let _ = unsafe { vtable_align_coerced_wrapper::<OverAligned16>(ptr) };
+    }
+
+    // Behavioral probe: check Kani's no-body `arith_offset` model with an in-bounds offset.
+    // `library/core/src/ptr/const_ptr.rs` gives `arith_offset` no call preconditions.
+    #[kani::proof]
+    pub fn check_arith_offset_no_ub() {
+        let arr: [u8; 8] = kani::any();
+        let base = arr.as_ptr();
+        let offset: isize = kani::any();
+        kani::assume(offset >= 0 && offset <= 8);
+        let p = unsafe { arith_offset(base, offset) };
+        assert_eq!(p as usize, (base as usize).wrapping_add(offset as usize));
+        kani::cover(p as usize != base as usize, "nonzero offset reached");
+    }
+
+    // Check `ptr_offset_from` on two positions in one array against their index difference.
+    #[kani::proof]
+    pub fn check_ptr_offset_from_no_ub() {
+        let arr: [u8; 8] = kani::any();
+        let base = arr.as_ptr();
+        let i: usize = kani::any();
+        let j: usize = kani::any();
+        kani::assume(i <= 8 && j <= 8);
+        let pi = unsafe { base.add(i) };
+        let pj = unsafe { base.add(j) };
+        let d = unsafe { ptr_offset_from(pi, pj) };
+        assert_eq!(d, i as isize - j as isize);
+        kani::cover(pi as usize != pj as usize, "nonzero offset reached");
+    }
+
+    // Check non-negative `ptr_offset_from_unsigned` against the unsigned index difference.
+    #[kani::proof]
+    pub fn check_ptr_offset_from_unsigned_no_ub() {
+        let arr: [u8; 8] = kani::any();
+        let base = arr.as_ptr();
+        let i: usize = kani::any();
+        let j: usize = kani::any();
+        kani::assume(i <= 8 && j <= 8 && i >= j);
+        let pi = unsafe { base.add(i) };
+        let pj = unsafe { base.add(j) };
+        let d = unsafe { ptr_offset_from_unsigned(pi, pj) };
+        assert_eq!(d, i - j);
+        kani::cover(d > 0, "nonzero unsigned offset reached");
+    }
+
+    // Check `read_via_copy` against an ordinary assignment as an independent oracle.
+    #[kani::proof]
+    pub fn check_read_via_copy_no_ub() {
+        let val: u32 = kani::any();
+        let local = val;
+        let ptr: *const u32 = &local;
+        let read_back = unsafe { read_via_copy(ptr) };
+        assert_eq!(read_back, val);
+        kani::cover(read_back == val, "read_via_copy reproduced the written value");
+    }
+
+    // Check `write_via_move` with an independent plain pointer read.
+    #[kani::proof]
+    pub fn check_write_via_move_no_ub() {
+        let val: u32 = kani::any();
+        let mut local: u32 = kani::any();
+        let ptr: *mut u32 = &mut local;
+        unsafe { write_via_move(ptr, val) };
+        let observed = unsafe { *ptr };
+        assert_eq!(observed, val);
+        kani::cover(observed == val, "write_via_move's write is observable via a plain deref");
+    }
+
+    // Check `compare_bytes` against an independent lexicographic comparison of two-byte arrays.
+    // Cover equal, less, and greater results.
+    fn lexicographic_cmp_u8(a: &[u8; 2], b: &[u8; 2]) -> core::cmp::Ordering {
+        match a[0].cmp(&b[0]) {
+            core::cmp::Ordering::Equal => a[1].cmp(&b[1]),
+            other => other,
+        }
+    }
+
+    #[kani::proof]
+    pub fn check_compare_bytes_no_ub() {
+        let left: [u8; 2] = kani::any();
+        let right: [u8; 2] = kani::any();
+        let result = unsafe { compare_bytes(left.as_ptr(), right.as_ptr(), 2) };
+        let expected = lexicographic_cmp_u8(&left, &right);
+        match expected {
+            core::cmp::Ordering::Equal => assert_eq!(result, 0),
+            core::cmp::Ordering::Less => assert!(result < 0),
+            core::cmp::Ordering::Greater => assert!(result > 0),
+        }
+        kani::cover(result == 0, "compare_bytes: equal buffers reached");
+        kani::cover(result < 0, "compare_bytes: left < right reached");
+        kani::cover(result > 0, "compare_bytes: left > right reached");
+    }
+
+    // Check sized `size_of_val` against the independent `size_of::<T>()` builtin.
+    #[kani::proof]
+    pub fn check_size_of_val_u32_no_ub() {
+        let val: u32 = kani::any();
+        let ptr: *const u32 = &val;
+        let sz = unsafe { size_of_val(ptr) };
+        assert_eq!(sz, core::mem::size_of::<u32>());
+        kani::cover(sz == 4, "size_of_val(&u32) reached the expected byte count");
+    }
+
+    // kani#3325 blocks contracts, but not plain proofs, on these no-body intrinsics.
+
+    // Check `copy_nonoverlapping` against an independent element-wise copy.
+    #[kani::proof]
+    pub fn check_copy_nonoverlapping_no_ub() {
+        const N: usize = 4;
+        let src: [u32; N] = kani::any();
+        let mut dst: [u32; N] = kani::any();
+        let mut oracle = dst;
+        unsafe { copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), N) };
+        for i in 0..N {
+            oracle[i] = src[i];
+        }
+        assert_eq!(dst, oracle);
+        kani::cover(dst == src, "copy_nonoverlapping: dst now equals src (full copy observed)");
+    }
+
+    // Check `copy` against an independent overlap-safe element-wise copy.
+    #[kani::proof]
+    pub fn check_copy_no_ub() {
+        const N: usize = 4;
+        let src: [u32; N] = kani::any();
+        let mut dst: [u32; N] = kani::any();
+        let mut oracle = dst;
+        unsafe { copy(src.as_ptr(), dst.as_mut_ptr(), N) };
+        for i in 0..N {
+            oracle[i] = src[i];
+        }
+        assert_eq!(dst, oracle);
+    }
+
+    // Kani 0.65.0 and CBMC 6.7.1 failed symbolic-offset `memmove` but accepted a fixed shift.
+    // Kani d4df833 verifies the general overlap contract in `check_copy`.
+    // Keep this fixed-shift proof as a small cross-check.
+    #[kani::proof]
+    pub fn check_copy_overlapping_shift_no_ub() {
+        const N: usize = 4;
+        const SHIFT: usize = 3; // fixed representative shift (1 <= SHIFT < N); see limitation note above
+        let mut buf: [u32; N] = kani::any();
+        let original = buf;
+        // Test a self-overlapping right shift.
+        let src_ptr = buf.as_ptr();
+        let dst_ptr = unsafe { buf.as_mut_ptr().add(SHIFT) };
+        unsafe { copy(src_ptr, dst_ptr, N - SHIFT) };
+        // A symbolic index can select any failing element.
+        let i: usize = kani::any();
+        kani::assume(i < N - SHIFT);
+        assert_eq!(buf[i + SHIFT], original[i]);
+        kani::cover(
+            true,
+            "copy: self-overlapping right shift completed with the expected post-state",
+        );
+    }
+
+    // This plain `volatile_set_memory` proof avoids the zero-byte contract case in kani#90.
+    // Kani reports `volatile_set_memory` as unsupported, so preserve it under `#[cfg(not(kani))]`.
+    #[cfg(not(kani))]
+    #[kani::proof]
+    pub fn check_volatile_set_memory_no_ub() {
+        const N: usize = 4;
+        let mut buf: [u8; N] = kani::any();
+        let val: u8 = kani::any();
+        unsafe { volatile_set_memory(buf.as_mut_ptr(), val, N) };
+        for i in 0..N {
+            assert_eq!(buf[i], val);
+        }
+        kani::cover(true, "volatile_set_memory: buffer fully set to val");
+    }
+
+    // Check the observable `volatile_copy_nonoverlapping_memory` result.
+    // Kani reports this intrinsic as unsupported.
+    #[cfg(not(kani))]
+    #[kani::proof]
+    pub fn check_volatile_copy_nonoverlapping_memory_no_ub() {
+        const N: usize = 4;
+        let src: [u32; N] = kani::any();
+        let mut dst: [u32; N] = kani::any();
+        let mut oracle = dst;
+        unsafe { volatile_copy_nonoverlapping_memory(dst.as_mut_ptr(), src.as_ptr(), N) };
+        for i in 0..N {
+            oracle[i] = src[i];
+        }
+        assert_eq!(dst, oracle);
+    }
+
+    // Check `volatile_copy_memory` with a self-overlapping shift.
+    // Kani reports this intrinsic as unsupported.
+    #[cfg(not(kani))]
+    #[kani::proof]
+    pub fn check_volatile_copy_memory_no_ub() {
+        const N: usize = 4;
+        // Use a fixed shift and a symbolic checked index, as in the `copy` cross-check.
+        const SHIFT: usize = 3; // fixed representative shift (1 <= SHIFT < N)
+        let mut buf: [u32; N] = kani::any();
+        let original = buf;
+        let src_ptr = buf.as_ptr();
+        let dst_ptr = unsafe { buf.as_mut_ptr().add(SHIFT) };
+        unsafe { volatile_copy_memory(dst_ptr, src_ptr, N - SHIFT) };
+        let i: usize = kani::any();
+        kani::assume(i < N - SHIFT);
+        assert_eq!(buf[i + SHIFT], original[i]);
+        kani::cover(
+            true,
+            "volatile_copy_memory: self-overlapping shift completed with the expected post-state",
+        );
+    }
+
+    // Check `volatile_load` and `volatile_store` with local round trips.
+    #[kani::proof]
+    pub fn check_volatile_load_no_ub() {
+        let val: u32 = kani::any();
+        let local = val;
+        let ptr: *const u32 = &local;
+        let read_back = unsafe { volatile_load(ptr) };
+        assert_eq!(read_back, val);
+        kani::cover(read_back == val, "volatile_load reproduced the written value");
+    }
+
+    #[kani::proof]
+    pub fn check_volatile_store_no_ub() {
+        let val: u32 = kani::any();
+        let mut local: u32 = kani::any();
+        let ptr: *mut u32 = &mut local;
+        unsafe { volatile_store(ptr, val) };
+        let observed = unsafe { *ptr };
+        assert_eq!(observed, val);
+        kani::cover(observed == val, "volatile_store's write is observable via a plain deref");
+    }
+
+    // Check unaligned volatile round trips at any valid byte offset.
+    // Kani reports `unaligned_volatile_load` and `unaligned_volatile_store` as unsupported.
+    #[cfg(not(kani))]
+    #[kani::proof]
+    pub fn check_unaligned_volatile_load_no_ub() {
+        let mut buf: [u8; 8] = kani::any();
+        let val: u32 = kani::any();
+        let offset: usize = kani::any();
+        kani::assume(offset <= 4); // leaves room for a full 4-byte u32 read in the 8-byte buffer
+        let bytes = val.to_ne_bytes();
+        buf[offset..offset + 4].copy_from_slice(&bytes);
+        let ptr = unsafe { buf.as_ptr().add(offset) } as *const u32;
+        let read_back = unsafe { unaligned_volatile_load(ptr) };
+        assert_eq!(read_back, val);
+        kani::cover(
+            read_back == val,
+            "unaligned_volatile_load reproduced the written value at a possibly-misaligned offset",
+        );
+    }
+
+    #[cfg(not(kani))]
+    #[kani::proof]
+    pub fn check_unaligned_volatile_store_no_ub() {
+        let mut buf: [u8; 8] = kani::any();
+        let val: u32 = kani::any();
+        let offset: usize = kani::any();
+        kani::assume(offset <= 4);
+        let ptr = unsafe { buf.as_mut_ptr().add(offset) } as *mut u32;
+        unsafe { unaligned_volatile_store(ptr, val) };
+        let mut observed = [0u8; 4];
+        observed.copy_from_slice(&buf[offset..offset + 4]);
+        assert_eq!(u32::from_ne_bytes(observed), val);
+        kani::cover(
+            u32::from_ne_bytes(observed) == val,
+            "unaligned_volatile_store's write is observable at a possibly-misaligned offset",
+        );
+    }
+
+    // `min_align_of_val` is a deprecated wrapper around `align_of_val`, not another intrinsic.
+    // Check that forwarding for one sized type.
+    #[kani::proof]
+    pub fn check_min_align_of_val_no_ub() {
+        let val: u32 = kani::any();
+        #[allow(deprecated)]
+        let min_align = core::mem::min_align_of_val(&val);
+        let align = core::mem::align_of_val(&val);
+        assert_eq!(min_align, align);
+        assert_eq!(min_align, core::mem::align_of::<u32>());
+        kani::cover(min_align == 4, "min_align_of_val(&u32) reached the expected alignment");
+    }
+
+    // Plainly probe `vtable_size` and `vtable_align` despite kani#3325.
+    // Compare a real `u32` `DynMetadata` with independent `size_of` and `align_of` values.
+    #[kani::proof]
+    pub fn check_vtable_size_align_no_ub() {
+        let val: u32 = kani::any();
+        let debug_ref: &dyn core::fmt::Debug = &val;
+        let meta = crate::ptr::metadata(debug_ref as *const dyn core::fmt::Debug);
+        let size = meta.size_of();
+        let align = meta.align_of();
+        assert_eq!(size, core::mem::size_of::<u32>());
+        assert_eq!(align, core::mem::align_of::<u32>());
+        kani::cover(size == 4 && align == 4, "vtable_size/vtable_align reached u32's real layout");
     }
 
     fn run_with_arbitrary_ptrs<T: Arbitrary>(harness: impl Fn(*mut T, *mut T)) {
@@ -4143,10 +5133,7 @@ mod verify {
         harness(src, dst);
     }
 
-    /// Return whether the current status is supported by Kani's contract.
-    ///
-    /// Kani memory predicates currently doesn't support pointers to dangling or dead allocations.
-    /// Thus, we have to explicitly exclude those cases.
+    /// Return whether Kani's memory predicates support this allocation status.
     fn supported_status(status: AllocationStatus) -> bool {
         status != AllocationStatus::Dangling && status != AllocationStatus::DeadObject
     }

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2948,26 +2948,45 @@ where
 #[rustc_intrinsic]
 pub const fn ptr_metadata<P: ptr::Pointee<Metadata = M> + PointeeSized, M>(ptr: *const P) -> M;
 
-/// Return whether the initialization state is preserved.
+/// Check one destination byte against a source byte captured before an overlapping [`copy`].
 ///
-/// For untyped copy (`copy` and `copy_nonoverlapping`), copying an uninitialized byte (such as a
-/// padding byte) produces an uninitialized byte. Copying an initialized byte produces an
-/// initialized byte.
+/// The caller chooses `elem` and `byte` and reads `src_byte_before` in a Kani `old(...)` history
+/// expression. That observation time matters because `copy` permits overlap: the call may overwrite
+/// the live source before its postcondition is evaluated.
 ///
-/// Reading an uninitialized byte is UB, so this check compares only initialization state, never
-/// byte values.
-///
-/// This is used for contracts only.
+/// This is a Kani-model byte-value check, not an initialization check. At the repository's Kani
+/// pin without `-Z uninit-checks`, CBMC represents an unwritten byte as an arbitrary but stable
+/// value; the model therefore permits a pre/post value comparison but no Rust-semantic claim about
+/// initialization. This is used for contracts only.
 #[allow(dead_code)]
 #[allow(unused_variables)]
-fn check_copy_untyped<T>(src: *const T, dst: *mut T, count: usize) -> bool {
+fn check_copy_untyped<T>(
+    dst: *mut T,
+    count: usize,
+    src_byte_before: u8,
+    elem: usize,
+    byte: usize,
+) -> bool {
+    #[cfg(kani)]
+    return elem < count
+        && byte < size_of::<T>()
+        && (unsafe { *((dst.add(elem) as *const u8).add(byte)) }) == src_byte_before;
+    #[cfg(not(kani))]
+    return false;
+}
+
+/// Check the Kani memory predicate after a non-overlapping untyped copy.
+///
+/// Unlike [`copy`], [`copy_nonoverlapping`] cannot overwrite its source under its contract, so a
+/// post-state source observation is not stale. At the current Kani pin this predicate does not
+/// distinguish initialized from uninitialized bytes unless `-Z uninit-checks` is enabled; it is
+/// retained as the existing non-overlapping safety/model check, not as a byte-value check.
+#[allow(dead_code)]
+#[allow(unused_variables)]
+fn check_copy_nonoverlapping_untyped<T>(src: *const T, dst: *mut T, count: usize) -> bool {
     #[cfg(kani)]
     if count > 0 {
-        // Inspect a non-deterministically chosen byte in the copy.
         let byte = kani::any_where(|sz: &usize| *sz < size_of::<T>());
-        // Instead of checking every one of the `count` copies, this picks one
-        // non-deterministically and inspects it. Quantifiers add no value here: the solver already
-        // picks an uninitialized element if one exists.
         let elem = kani::any_where(|val: &usize| *val < count);
         let src_data = unsafe { src.add(elem) } as *const u8;
         let dst_data = unsafe { dst.add(elem) } as *const u8;
@@ -2997,7 +3016,7 @@ fn check_copy_untyped<T>(src: *const T, dst: *mut T, count: usize) -> bool {
 //   && ub_checks::can_dereference(core::ptr::slice_from_raw_parts(src as *const crate::mem::MaybeUninit<T>, count))
 //   && ub_checks::can_write(core::ptr::slice_from_raw_parts_mut(dst, count))
 //   && ub_checks::maybe_is_nonoverlapping(src as *const (), dst as *const (), size_of::<T>(), count))]
-// #[ensures(|_| { check_copy_untyped(src, dst, count)})]
+// #[ensures(|_| { check_copy_nonoverlapping_untyped(src, dst, count)})]
 pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
 
 /// This is an accidentally-stable alias to [`ptr::copy`]; use that instead.
@@ -3014,7 +3033,8 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 // #[requires(!count.overflowing_mul(size_of::<T>()).1
 //   && ub_checks::can_dereference(core::ptr::slice_from_raw_parts(src as *const crate::mem::MaybeUninit<T>, count))
 //   && ub_checks::can_write(core::ptr::slice_from_raw_parts_mut(dst, count)))]
-// #[ensures(|_| { check_copy_untyped(src, dst, count) })]
+// The pre-state byte-value postcondition lives on `verify::copy_wrapper` below because it uses
+// Kani's `old(...)` history expression.
 // #[cfg_attr(kani, kani::modifies(crate::ptr::slice_from_raw_parts(dst, count)))]
 pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize);
 
@@ -3550,7 +3570,7 @@ mod verify {
         && ub_checks::can_dereference(core::ptr::slice_from_raw_parts(src as *const crate::mem::MaybeUninit<T>, count))
         && ub_checks::can_write(core::ptr::slice_from_raw_parts_mut(dst, count))
         && ub_checks::maybe_is_nonoverlapping(src as *const (), dst as *const (), size_of::<T>(), count))]
-    #[ensures(|_| check_copy_untyped(src, dst, count))]
+    #[ensures(|_| check_copy_nonoverlapping_untyped(src, dst, count))]
     #[kani::modifies(crate::ptr::slice_from_raw_parts(dst, count))]
     #[allow(dead_code)]
     unsafe fn copy_nonoverlapping_wrapper<T>(src: *const T, dst: *mut T, count: usize) {
@@ -3560,7 +3580,21 @@ mod verify {
     #[requires(!count.overflowing_mul(size_of::<T>()).1
         && ub_checks::can_dereference(core::ptr::slice_from_raw_parts(src as *const crate::mem::MaybeUninit<T>, count))
         && ub_checks::can_write(core::ptr::slice_from_raw_parts_mut(dst, count)))]
-    #[ensures(|_| check_copy_untyped(src, dst, count))]
+    #[ensures(|_| {
+        if count > 0 && size_of::<T>() > 0 {
+            // Select the byte and capture its value before the call. A post-state source read is
+            // unsound for an overlap-capable move because the destination may cover that byte.
+            let (src_byte_before, elem, byte) = old({
+                let elem = kani::any_where(|e: &usize| *e < count);
+                let byte = kani::any_where(|b: &usize| *b < size_of::<T>());
+                let src_byte_before = unsafe { *((src.add(elem) as *const u8).add(byte)) };
+                (src_byte_before, elem, byte)
+            });
+            check_copy_untyped(dst, count, src_byte_before, elem, byte)
+        } else {
+            true
+        }
+    })]
     #[kani::modifies(crate::ptr::slice_from_raw_parts(dst, count))]
     #[allow(dead_code)]
     unsafe fn copy_wrapper<T>(src: *const T, dst: *mut T, count: usize) {
@@ -3599,11 +3633,12 @@ mod verify {
                 requires_hold && overlap,
                 "copy: contract-admissible overlapping src/dst (count>0) is reachable",
             );
-            // Witness valid overlap with a source not fully initialized as `char`.
-            // This makes the `check_copy_untyped` initialization oracle non-trivial.
+            // At this Kani pin, this is a validity/alignment/in-bounds partition, not an
+            // initialization observation. The pre-state byte check above is therefore a
+            // model-relative value PROBE; it makes no Rust-semantic initialization claim.
             kani::cover(
                 requires_hold && overlap && !ub_checks::can_dereference(src as *const char),
-                "copy: overlapping call with a non-fully-initialized source is reachable",
+                "copy: overlapping call with a source not valid as a whole char is reachable",
             );
             unsafe { copy_wrapper(src, dst, count) }
         });
@@ -4232,17 +4267,17 @@ mod verify {
     #[requires(offset >= 0 && offset <= 8)]
     #[ensures(|result| *result as usize == (dst as usize).wrapping_add(offset as usize))]
     #[allow(dead_code)]
-    unsafe fn arith_offset_wrapper(dst: *const u8, offset: isize) -> *const u8 {
+    unsafe fn arith_offset_bounded_probe(dst: *const u8, offset: isize) -> *const u8 {
         unsafe { arith_offset(dst, offset) }
     }
 
-    #[kani::proof_for_contract(arith_offset_wrapper)]
-    pub fn check_arith_offset_wrapper_contract() {
+    #[kani::proof_for_contract(arith_offset_bounded_probe)]
+    pub fn check_arith_offset_bounded_probe() {
         let arr: [u8; 8] = kani::any();
         let base = arr.as_ptr();
         // The bound scopes only the pointer-model probe, not safety.
         let offset: isize = kani::any();
-        let _ = unsafe { arith_offset_wrapper(base, offset) };
+        let _ = unsafe { arith_offset_bounded_probe(base, offset) };
     }
 
     // Check unconditional `arith_offset` safety for every `offset: isize`.
@@ -4312,6 +4347,121 @@ mod verify {
         let pi = if pi_from_a { unsafe { base_a.add(i) } } else { unsafe { base_b.add(i) } };
         let pj = if pj_from_a { unsafe { base_a.add(j) } } else { unsafe { base_b.add(j) } };
         let _ = unsafe { ptr_offset_from_unsigned_wrapper(pi, pj) };
+    }
+
+    // The u8 wrappers above cannot exercise their `% size_of::<T>()` conjunct: `% 1 == 0`.
+    // Byte storage plus u32 pointer views permits both divisible and non-divisible byte distances
+    // without dereferencing a possibly unaligned u32 pointer. These bounded monomorphizations are
+    // PROBEs of the candidate contracts, not generic-T CONTRACT evidence.
+    const PTR_OFFSET_U32_BYTES: usize = 16;
+
+    #[requires(
+        (ptr as isize).checked_sub(base as isize).is_some()
+            && (ptr as isize - base as isize) % (size_of::<u32>() as isize) == 0
+            && (ptr as isize == base as isize || ub_checks::same_allocation(ptr, base))
+    )]
+    #[ensures(|result| *result == (ptr as isize - base as isize) / (size_of::<u32>() as isize))]
+    #[allow(dead_code)]
+    unsafe fn ptr_offset_from_u32_wrapper(ptr: *const u32, base: *const u32) -> isize {
+        unsafe { ptr_offset_from(ptr, base) }
+    }
+
+    #[kani::proof_for_contract(ptr_offset_from_u32_wrapper)]
+    pub fn check_ptr_offset_from_u32_wrapper_contract() {
+        let arr_a: [u8; PTR_OFFSET_U32_BYTES] = kani::any();
+        let arr_b: [u8; PTR_OFFSET_U32_BYTES] = kani::any();
+        let base_a = arr_a.as_ptr();
+        let base_b = arr_b.as_ptr();
+        let i: usize = kani::any();
+        let j: usize = kani::any();
+        kani::assume(i < PTR_OFFSET_U32_BYTES && j < PTR_OFFSET_U32_BYTES);
+        let pi_from_a: bool = kani::any();
+        let pj_from_a: bool = kani::any();
+        let ptr = if pi_from_a { unsafe { base_a.add(i) } } else { unsafe { base_b.add(i) } }
+            as *const u32;
+        let base = if pj_from_a { unsafe { base_a.add(j) } } else { unsafe { base_b.add(j) } }
+            as *const u32;
+        let requires_hold = (ptr as isize).checked_sub(base as isize).is_some()
+            && (ptr as isize - base as isize) % (size_of::<u32>() as isize) == 0
+            && (ptr as isize == base as isize || ub_checks::same_allocation(ptr, base));
+        kani::cover(
+            requires_hold && pi_from_a == pj_from_a && i > j && (i - j) % size_of::<u32>() == 0,
+            "ptr_offset_from u32: positive same-allocation element distance reached",
+        );
+        kani::cover(
+            requires_hold && pi_from_a == pj_from_a && j > i && (j - i) % size_of::<u32>() == 0,
+            "ptr_offset_from u32: negative same-allocation element distance reached",
+        );
+        let _ = unsafe { ptr_offset_from_u32_wrapper(ptr, base) };
+    }
+
+    #[requires(
+        (ptr as isize).checked_sub(base as isize).is_some()
+            && (ptr as isize - base as isize) % (size_of::<u32>() as isize) == 0
+            && (ptr as isize == base as isize || ub_checks::same_allocation(ptr, base))
+            && ptr as usize >= base as usize
+    )]
+    #[ensures(|result| *result == (ptr as usize - base as usize) / size_of::<u32>())]
+    #[allow(dead_code)]
+    unsafe fn ptr_offset_from_unsigned_u32_wrapper(ptr: *const u32, base: *const u32) -> usize {
+        unsafe { ptr_offset_from_unsigned(ptr, base) }
+    }
+
+    #[kani::proof_for_contract(ptr_offset_from_unsigned_u32_wrapper)]
+    pub fn check_ptr_offset_from_unsigned_u32_wrapper_contract() {
+        let arr_a: [u8; PTR_OFFSET_U32_BYTES] = kani::any();
+        let arr_b: [u8; PTR_OFFSET_U32_BYTES] = kani::any();
+        let base_a = arr_a.as_ptr();
+        let base_b = arr_b.as_ptr();
+        let i: usize = kani::any();
+        let j: usize = kani::any();
+        kani::assume(i < PTR_OFFSET_U32_BYTES && j < PTR_OFFSET_U32_BYTES);
+        let pi_from_a: bool = kani::any();
+        let pj_from_a: bool = kani::any();
+        let ptr = if pi_from_a { unsafe { base_a.add(i) } } else { unsafe { base_b.add(i) } }
+            as *const u32;
+        let base = if pj_from_a { unsafe { base_a.add(j) } } else { unsafe { base_b.add(j) } }
+            as *const u32;
+        let requires_hold = (ptr as isize).checked_sub(base as isize).is_some()
+            && (ptr as isize - base as isize) % (size_of::<u32>() as isize) == 0
+            && (ptr as isize == base as isize || ub_checks::same_allocation(ptr, base))
+            && ptr as usize >= base as usize;
+        kani::cover(
+            requires_hold && pi_from_a == pj_from_a && i > j && (i - j) % size_of::<u32>() == 0,
+            "ptr_offset_from_unsigned u32: ordered same-allocation element distance reached",
+        );
+        let _ = unsafe { ptr_offset_from_unsigned_u32_wrapper(ptr, base) };
+    }
+
+    // This fixture never calls either unsafe intrinsic on an invalid pair. It shows that the
+    // contract harness's domain reaches every adversarial class filtered by the u32 requires.
+    #[kani::proof]
+    pub fn check_ptr_offset_u32_fixture_partitions() {
+        let arr_a: [u8; PTR_OFFSET_U32_BYTES] = kani::any();
+        let arr_b: [u8; PTR_OFFSET_U32_BYTES] = kani::any();
+        let base_a = arr_a.as_ptr();
+        let base_b = arr_b.as_ptr();
+        let i: usize = kani::any();
+        let j: usize = kani::any();
+        kani::assume(i < PTR_OFFSET_U32_BYTES && j < PTR_OFFSET_U32_BYTES);
+        let pi_from_a: bool = kani::any();
+        let pj_from_a: bool = kani::any();
+        let ptr = if pi_from_a { unsafe { base_a.add(i) } } else { unsafe { base_b.add(i) } }
+            as *const u32;
+        let base = if pj_from_a { unsafe { base_a.add(j) } } else { unsafe { base_b.add(j) } }
+            as *const u32;
+        kani::cover(
+            pi_from_a != pj_from_a && !ub_checks::same_allocation(ptr, base),
+            "ptr_offset u32 fixture: cross-allocation pair rejected by same_allocation reached",
+        );
+        kani::cover(
+            pi_from_a == pj_from_a && i > j && (i - j) % size_of::<u32>() != 0,
+            "ptr_offset u32 fixture: same-allocation non-divisible byte delta reached",
+        );
+        kani::cover(
+            pi_from_a == pj_from_a && j > i && (j - i) % size_of::<u32>() == 0,
+            "ptr_offset unsigned u32 fixture: reversed ordered divisible pair reached",
+        );
     }
 
     // `read_via_copy` requires a projection-free local accepted by `can_dereference`.
@@ -4387,6 +4537,8 @@ mod verify {
         let right: [u8; CAP] = kani::any();
         let bytes: usize = kani::any();
         kani::assume(bytes <= CAP);
+        kani::cover(bytes > 0, "compare_bytes: nonzero harness length reached");
+        kani::cover(bytes == CAP, "compare_bytes: harness CAP boundary reached");
         let _ = unsafe { compare_bytes_wrapper(left.as_ptr(), right.as_ptr(), bytes) };
     }
 
@@ -4536,7 +4688,8 @@ mod verify {
         let _ = unsafe { size_of_val_slice_wrapper::<VtableZst>(ptr, len) };
     }
 
-    // Check `volatile_load` and `volatile_store` by value-preserving round trips.
+    // Check `volatile_load` and `volatile_store` by value-preserving round trips. These are
+    // Rust-allocation PROBEs, not complete documented-domain CONTRACTS.
     // Residual: `can_dereference` and `can_write` cover only Rust-backed allocations. Kani's
     // pointer model cannot represent the documented external-memory MMIO case.
     #[requires(ub_checks::can_dereference(src))]
@@ -4633,18 +4786,22 @@ mod verify {
         let _ = unsafe { vtable_align_wrapper::<u64>(vtable_ptr) };
     }
 
-    // General `vtable_size` and `vtable_align` contracts.
-    // Taking `*const T` and unsizing inside the wrapper binds the vtable to `T`.
-    // Kani emits its `codegen_vtable`, so callers cannot substitute another type's vtable.
-    // The wrapper establishes the documented vtable precondition and needs no `#[requires]`.
+    // Candidate `vtable_size` and `vtable_align` contracts. Criterion-3 correspondence is:
+    // `*const T` -> unsize coercion to `*const dyn Debug` -> `DynMetadata` -> raw vtable pointer ->
+    // size/alignment slots -> comparison with `size_of::<T>()`/`align_of::<T>()`.
+    // Taking `*const T` and unsizing inside the wrapper binds the vtable to `T`. Kani emits its
+    // `codegen_vtable`, so callers cannot substitute another type's vtable. The wrapper establishes
+    // the documented vtable precondition and needs no `#[requires]`.
     // Residual: rustc's `layout_of` supplies both the vtable constant and `size_of::<T>()`.
     // The proof still checks vtable selection, `Kani::CommonVTable` slot layout, and rustc's value
     // against CBMC's independent `__CPROVER_OBJECT_SIZE` value.
     // It cannot detect `layout_of` disagreeing with the final LLVM vtable.
-    // Residual: the wrappers use only `core::fmt::Debug`. Rustc fixes size, align, and drop as the
-    // first three slots for every trait, but this does not prove all traits.
+    // Residual: the finite harness set monomorphizes only seven layouts, and the wrappers use only
+    // `core::fmt::Debug`. Rustc fixes size, align, and drop as the first three slots for every trait,
+    // but these model-relative proofs do not prove all types/traits or final LLVM vtable emission.
     // Keep the raw `*const ()` wrappers above as monomorphic probes of the intrinsic's exact form.
-    // Only these typed contracts count as general contracts.
+    // Only the typed wrappers are candidate contract surfaces; each finite harness remains a PROBE
+    // until a separate genericity/model-correspondence argument supports promotion.
     #[ensures(|result| *result == core::mem::size_of::<T>())]
     #[allow(dead_code)]
     unsafe fn vtable_size_coerced_wrapper<T: core::fmt::Debug>(ptr: *const T) -> usize {
@@ -4965,26 +5122,29 @@ mod verify {
         assert_eq!(dst, oracle);
     }
 
-    // Kani 0.65.0 and CBMC 6.7.1 failed symbolic-offset `memmove` but accepted a fixed shift.
-    // Kani d4df833 verifies the general overlap contract in `check_copy`.
-    // Keep this fixed-shift proof as a small cross-check.
+    // Tool-limit R11 affects symbolic-count copy-family calls with multi-byte T. Keep this
+    // concrete-count u32 PROBE as a tractable overlap discriminator, not a generic contract claim.
     #[kani::proof]
     pub fn check_copy_overlapping_shift_no_ub() {
         const N: usize = 4;
-        const SHIFT: usize = 3; // fixed representative shift (1 <= SHIFT < N); see limitation note above
+        // Source [0, COUNT) and destination [SHIFT, SHIFT + COUNT) genuinely overlap.
+        const SHIFT: usize = 1;
+        const COUNT: usize = N - SHIFT;
+        const RANGES_OVERLAP: bool = SHIFT < COUNT;
+        assert!(RANGES_OVERLAP);
         let mut buf: [u32; N] = kani::any();
         let original = buf;
         // Test a self-overlapping right shift.
         let src_ptr = buf.as_ptr();
         let dst_ptr = unsafe { buf.as_mut_ptr().add(SHIFT) };
-        unsafe { copy(src_ptr, dst_ptr, N - SHIFT) };
+        unsafe { copy(src_ptr, dst_ptr, COUNT) };
         // A symbolic index can select any failing element.
         let i: usize = kani::any();
-        kani::assume(i < N - SHIFT);
+        kani::assume(i < COUNT);
         assert_eq!(buf[i + SHIFT], original[i]);
         kani::cover(
-            true,
-            "copy: self-overlapping right shift completed with the expected post-state",
+            RANGES_OVERLAP,
+            "copy: source and destination ranges genuinely overlap",
         );
     }
 

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2957,7 +2957,7 @@ pub const fn ptr_metadata<P: ptr::Pointee<Metadata = M> + PointeeSized, M>(ptr: 
 /// This is a Kani-model byte-value check, not an initialization check. At the repository's Kani
 /// pin without `-Z uninit-checks`, CBMC represents an unwritten byte as an arbitrary but stable
 /// value; the model therefore permits a pre/post value comparison but no Rust-semantic claim about
-/// initialization. This is used for contracts only.
+/// initialization. This helper is referenced only from contract `ensures` clauses.
 #[allow(dead_code)]
 #[allow(unused_variables)]
 fn check_copy_untyped<T>(
@@ -3581,15 +3581,19 @@ mod verify {
         && ub_checks::can_dereference(core::ptr::slice_from_raw_parts(src as *const crate::mem::MaybeUninit<T>, count))
         && ub_checks::can_write(core::ptr::slice_from_raw_parts_mut(dst, count)))]
     #[ensures(|_| {
-        if count > 0 && size_of::<T>() > 0 {
-            // Select the byte and capture its value before the call. A post-state source read is
-            // unsound for an overlap-capable move because the destination may cover that byte.
-            let (src_byte_before, elem, byte) = old({
+        let (src_byte_before, elem, byte) = old({
+            if count > 0 && size_of::<T>() > 0 {
+                // Select the byte and capture its value before the call. A post-state source read is
+                // unsound for an overlap-capable move because the destination may cover that byte.
                 let elem = kani::any_where(|e: &usize| *e < count);
                 let byte = kani::any_where(|b: &usize| *b < size_of::<T>());
                 let src_byte_before = unsafe { *((src.add(elem) as *const u8).add(byte)) };
                 (src_byte_before, elem, byte)
-            });
+            } else {
+                (0u8, 0usize, 0usize)
+            }
+        });
+        if count > 0 && size_of::<T>() > 0 {
             check_copy_untyped(dst, count, src_byte_before, elem, byte)
         } else {
             true
@@ -3640,7 +3644,8 @@ mod verify {
                 requires_hold && overlap && !ub_checks::can_dereference(src as *const char),
                 "copy: overlapping call with a source not valid as a whole char is reachable",
             );
-            unsafe { copy_wrapper(src, dst, count) }
+            unsafe { copy_wrapper(src, dst, count) };
+            kani::cover(count == 0, "copy: zero-count contract call returns");
         });
     }
 
@@ -5179,14 +5184,14 @@ mod verify {
         assert_eq!(dst, oracle);
     }
 
-    // Check `volatile_copy_memory` with a self-overlapping shift.
+    // Check `volatile_copy_memory` with fixed disjoint source and destination regions.
     // Kani reports this intrinsic as unsupported.
     #[cfg(not(kani))]
     #[kani::proof]
     pub fn check_volatile_copy_memory_no_ub() {
         const N: usize = 4;
         // Use a fixed shift and a symbolic checked index, as in the `copy` cross-check.
-        const SHIFT: usize = 3; // fixed representative shift (1 <= SHIFT < N)
+        const SHIFT: usize = 3; // N - SHIFT == 1, so the one-element regions are disjoint.
         let mut buf: [u32; N] = kani::any();
         let original = buf;
         let src_ptr = buf.as_ptr();
@@ -5197,7 +5202,7 @@ mod verify {
         assert_eq!(buf[i + SHIFT], original[i]);
         kani::cover(
             true,
-            "volatile_copy_memory: self-overlapping shift completed with the expected post-state",
+            "volatile_copy_memory: disjoint shifted copy completed with the expected post-state",
         );
     }
 

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3649,6 +3649,27 @@ mod verify {
         });
     }
 
+    // CONTRACT-CHECKING positive witness for the temporal `old(...)` relation above. Fixed,
+    // initialized, nonuniform source contents make the right-overlap change a still-live source
+    // element, so this fixture detects a post-state source observation masquerading as pre-state.
+    #[kani::proof_for_contract(copy_wrapper)]
+    pub fn check_copy_wrapper_overlapping_nonuniform_contract() {
+        const N: usize = 4;
+        const SHIFT: usize = 1;
+        const COUNT: usize = N - SHIFT;
+        const RANGES_OVERLAP: bool = SHIFT < COUNT;
+        const INITIAL: [u32; N] = [0x1020_3040, 0x5162_7384, 0x95a6_b7c8, 0xd9ea_fb0c];
+        let mut buf = INITIAL;
+        let original = buf;
+        let src = buf.as_ptr();
+        let dst = unsafe { buf.as_mut_ptr().add(SHIFT) };
+        unsafe { copy_wrapper(src, dst, COUNT) };
+        kani::cover(
+            RANGES_OVERLAP && buf[SHIFT] == original[0] && buf[SHIFT] != original[SHIFT],
+            "copy wrapper: nontrivial overlap returns after changing a live source element",
+        );
+    }
+
     #[kani::proof_for_contract(copy_nonoverlapping_wrapper)]
     fn check_copy_nonoverlapping() {
         // `ArbitraryPointer` calls `copy_nonoverlapping`, which this contract check forbids.
@@ -4439,7 +4460,8 @@ mod verify {
     }
 
     // This fixture never calls either unsafe intrinsic on an invalid pair. It shows that the
-    // contract harness's domain reaches every adversarial class filtered by the u32 requires.
+    // contract harness's domain reaches the three named adversarial classes filtered by the u32
+    // requires.
     #[kani::proof]
     pub fn check_ptr_offset_u32_fixture_partitions() {
         let arr_a: [u8; PTR_OFFSET_U32_BYTES] = kani::any();

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -4377,8 +4377,8 @@ mod verify {
 
     // The u8 wrappers above cannot exercise their `% size_of::<T>()` conjunct: `% 1 == 0`.
     // Byte storage plus u32 pointer views permits both divisible and non-divisible byte distances
-    // without dereferencing a possibly unaligned u32 pointer. These bounded monomorphizations are
-    // PROBEs of the candidate contracts, not generic-T CONTRACT evidence.
+    // without dereferencing a possibly unaligned u32 pointer. These bounded monomorphizations
+    // probe the contracts above; they are not generic-T evidence.
     const PTR_OFFSET_U32_BYTES: usize = 16;
 
     #[requires(
@@ -4813,7 +4813,7 @@ mod verify {
         let _ = unsafe { vtable_align_wrapper::<u64>(vtable_ptr) };
     }
 
-    // Candidate `vtable_size` and `vtable_align` contracts. Criterion-3 correspondence is:
+    // The `vtable_size` and `vtable_align` contracts. Criterion-3 correspondence is:
     // `*const T` -> unsize coercion to `*const dyn Debug` -> `DynMetadata` -> raw vtable pointer ->
     // size/alignment slots -> comparison with `size_of::<T>()`/`align_of::<T>()`.
     // Taking `*const T` and unsizing inside the wrapper binds the vtable to `T`. Kani emits its
@@ -4827,7 +4827,7 @@ mod verify {
     // `core::fmt::Debug`. Rustc fixes size, align, and drop as the first three slots for every trait,
     // but these model-relative proofs do not prove all types/traits or final LLVM vtable emission.
     // Keep the raw `*const ()` wrappers above as monomorphic probes of the intrinsic's exact form.
-    // Only the typed wrappers are candidate contract surfaces; each finite harness remains a PROBE
+    // Only the typed wrappers are offered as contract surfaces; each finite harness remains a probe
     // until a separate genericity/model-correspondence argument supports promotion.
     #[ensures(|result| *result == core::mem::size_of::<T>())]
     #[allow(dead_code)]
@@ -5149,8 +5149,8 @@ mod verify {
         assert_eq!(dst, oracle);
     }
 
-    // Tool-limit R11 affects symbolic-count copy-family calls with multi-byte T. Keep this
-    // concrete-count u32 PROBE as a tractable overlap discriminator, not a generic contract claim.
+    // A symbolic count combined with a multi-byte T is intractable here. Keep this concrete-count
+    // u32 probe as a tractable overlap discriminator, not a generic contract claim.
     #[kani::proof]
     pub fn check_copy_overlapping_shift_no_ub() {
         const N: usize = 4;

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -5169,10 +5169,7 @@ mod verify {
         let i: usize = kani::any();
         kani::assume(i < COUNT);
         assert_eq!(buf[i + SHIFT], original[i]);
-        kani::cover(
-            RANGES_OVERLAP,
-            "copy: source and destination ranges genuinely overlap",
-        );
+        kani::cover(RANGES_OVERLAP, "copy: source and destination ranges genuinely overlap");
     }
 
     // This plain `volatile_set_memory` proof avoids the zero-byte contract case in kani#90.


### PR DESCRIPTION
# Challenge 2 (partial): safety contracts and verification for 15 of 20 raw-pointer `core::intrinsics`

Tracking issue: model-checking/verify-rust-std#16. **This PR does not close that issue.**
Scope: 14 safety contracts checked by `#[kani::proof_for_contract]` at bounded finite instantiations,
plus `arith_offset`'s unbounded no-UB proof. No generic theorem over all types and sizes is claimed.
Contracts use forwarding wrappers because kani#3325 blocks contracts on bodyless intrinsics (kani#3345).

Covered: `typed_swap` (`typed_swap_nonoverlapping`) · `vtable_size` · `vtable_align` · `copy` · `copy_nonoverlapping` ·
`write_bytes` · `size_of_val` · `arith_offset` · `volatile_load` · `volatile_store` · `ptr_offset_from` ·
`ptr_offset_from_unsigned` · `compare_bytes` · `read_via_copy` · `write_via_move`. Not covered: the five volatile
intrinsics under *Residuals*.

## Response to the 2026-08-16 review

Blocking items, in review order:

1. **`vtable_size_coerced_wrapper` / `vtable_align_coerced_wrapper`:** unsize `*const T` and compare with `size_of::<T>()` / `align_of::<T>()`.
   Checked at seven types through `Debug`, relative to compiler layout; raw `*const ()` probes are excluded from the count.
2. **`size_of_val_wrapper`:** no `#[requires]` for sized pointers; separate `dyn` and symbolic-length slice wrappers.
   Slices require only `size * len <= isize::MAX`; composite unsized tails and `extern type` remain residuals.
3. **`compare_bytes_wrapper`:** requires only both regions readable for `bytes`. `COMPARE_BYTES_CAP` is a harness `assume`;
   covers witness non-zero length and the exact cap boundary.
4. **`volatile_load_wrapper` / `volatile_store_wrapper`:** scope is Rust-allocation-backed memory only.
   Documented aligned, non-trapping external-memory/MMIO access remains unverified.
5. **`arith_offset_bounded_probe` / `check_arith_offset_bounded_probe`:** excluded from the contract count.
   Safety rests on `check_arith_offset_unconditional_safety`, with a fully symbolic `isize` offset.

Non-blocking items:

- **`check_copy_untyped`:** pairs `src.add(elem)` with `dst.add(elem)`; `copy_wrapper` captures the source using `old(...)`.
  `check_copy_wrapper_overlapping_nonuniform_contract` checks the pre-state oracle on an overlapping non-uniform fixture.
- **Pointer-distance preconditions:** `check_ptr_offset_from_u32_wrapper_contract`, `check_ptr_offset_from_unsigned_u32_wrapper_contract`, and
  `check_ptr_offset_u32_fixture_partitions` exercise same/cross-allocation, forward/reverse order, and divisible/non-divisible distances; controls below.
- **Fallback duplication:** `typed_swap_nonoverlapping_fallback` is shared by the production fallback and verification wrapper.

## Evidence

Targeted/module runs: `c35c201b46a8be04daaef874defa438c8a5e945c`; the later
`cf5fd23c45cb38273a314d6229a9b214a16ebf3c` changes comments only. Repository-suite run: `cf5fd23c`.

| Tool / setting | Value |
|---|---|
| Kani | `d4df833c8f8f18e632e7b0a7945bb2161f708990` (`tool_config/kani-version.toml`) |
| CBMC | 6.8.0 |
| rustc | 1.93.0-nightly (c871d09d1 2025-11-24), nightly-2025-11-25 |
| Flags | `-Z unstable-options`, `-Z function-contracts -Z mem-predicates -Z float-lib -Z c-ffi -Z loop-contracts -Z quantifiers -Z stubbing`, `--cbmc-args --object-bits 12` |

| Run | Result |
|---|---|
| Targeted, both dependency-contract modes | 55/55; every declared `kani::cover` satisfied in both modes |
| `intrinsics::verify`, CI mode (`--no-assert-contracts`) | 374/374, 0 failures, exit 0 |
| `intrinsics::verify`, dependency contracts asserted | 372/374, 2 failures, exit 1 |
| Repository suite, four Linux shards, `cf5fd23c`, `--no-assert-contracts` | 1436 harnesses, 359 per shard, 0 failures |

The asserting-mode failures, `check_transmute_slice_metadata` and `check_transmute_unchecked_slice_metadata`,
stop at `--object-bits 12`: “too many addressed objects” (4096 objects), CBMC status 6, **not a property violation**.
The stop reproduces on the untouched base for `check_transmute_slice_metadata` and on the prior PR head for both;
the base `_unchecked` run timed out without a verdict. This revision does not introduce the capacity stop.
**A larger object budget is untested.**

All five added/renamed harnesses named in the review response appear in `kani list`, used for sharding.
**macOS was not run outside CI.** The PR's CI run remains authoritative; no CI outcome is claimed here.

## Controls

| Control | Change | Observed |
|---|---|---|
| Copy implementation | `copy_wrapper` call replaced by `write_bytes(dst, 0, count)` | Only the `ensures` postcondition fails, both modes |
| Copy readable-source precondition | Conjunct deleted | Memory-safety failures including pre-state source read, both modes |
| Copy writable-destination precondition | Conjunct deleted | Destination write, `modifies` validity, and postcondition destination read fail, both modes |
| Copy count-size overflow precondition | Conjunct deleted | **Survived.** Subsumed by other conjuncts in this fixture; independence unestablished |
| Pointer-distance preconditions (five) | Same-allocation, divisibility, unsigned-ordering conjuncts individually ablated across signed/unsigned `u32` wrappers | Each fails its named Kani model check, both modes |
| `mem::swap` drop detector | Harness epilogue's `forget` replaced by `drop` | Fixture's `Drop` panic; tests the detector, not the implementation |

Reversing each ablation restores success. The two copy memory-precondition ablations also hit an unsupported
`same_allocation` check and leave checks undetermined; only their separate memory-safety failures count as evidence.

## Criterion by criterion

| # | Criterion | Scope / gap |
|---|---|---|
| 1 | Safety contracts for all listed intrinsics | 15/20: 14 contract-form, plus `arith_offset` safety proof. **Not satisfied** for all 20. |
| 2 | Verify fallback implementations | The sole fallback, `typed_swap_nonoverlapping`, shares the helper symbolically executed through a wrapper. Equivalence to Kani's built-in model is not shown. |
| 3 | Explain model/definition correspondence | Value/pointer results use independently computed expectations; vtable correspondence is documented in source. Connection to bodyless intrinsic backend codegen remains open. |
| 4 | State assumptions and guarantees | Finite scope and assumptions below. |
| 5 | Documented conditions suffice for safety | Documented `requires`; caps in harnesses. Carve-outs: volatile MMIO is unverified; `arith_offset` uses the no-UB proof. Open for the five tool-blocked intrinsics. |

## Assumptions and bounds

- CI mode assumes dependency contracts (`--no-assert-contracts`); asserting-mode results are listed separately above.
- Copy byte-value postcondition: initialized `T = u32`, `N = 4`, `SHIFT = 1`, `COUNT = 3`, four distinct non-zero words;
  every element in `0..3` and byte in `0..4`. No generic `T` or count result.
- `check_copy`: `T = char`, two `PointerGenerator<100>` allocations, symbolic pointers/count;
  `Dangling` and `DeadObject` excluded by assumption.
- `-Z uninit-checks` is off; `can_dereference`'s initialization conjunct is inert. Copy checks are model-relative byte-value checks,
  with no Rust-semantic initialization claim or mixed-initialization relation.
- The overlap cover's overlap conjunct is constant; only its two value conjuncts are witnessed. No pointer-derived overlap predicate.
- `check_copy_overlapping_shift_no_ub`: `SHIFT = 1`, `COUNT = 3`, symbolic index; no exhaustive overlap sweep.
- Pointer distance: `u8`, one 8-byte allocation (divisibility unexercised); `u32`, two 16-byte allocations, offsets `0..16`; no generic `T` result.
- `mem::swap`: `T = u8` and a panic-on-`Drop` ADT; only `kani::modifies(x)` / `modifies(y)`, no `requires` or `ensures`.
  No value exchange proved; the ADT fixture witnesses no operand drop.
- Small concrete fixtures, symbolic contents; `compare_bytes` cap 4, unwind 5, cap assumed in harness.
- Vtables: seven erased types, only `Debug`; expected/result share compiler layout. Includes `[u8; 8]`, zero-sized, mixed-alignment, over-aligned types.
- `size_of_val`: sized `u32` (null, dangling, non-deterministic-address, real pointers), four `dyn` erased types, four slice element types.
- `arith_offset_bounded_probe`: `0..=8`; its unbounded safety proof is separate.
- `--object-bits 12` fails loudly on overflow; no silent cap.
- No Challenge-2 harness uses `kani::stub` or `stub_verified`, or compiles out a shipped body; `-Z stubbing` serves pre-existing transmute harnesses.
- Only the copy family has an implementation mutation. No control mutates Kani codegen; lowering defects are not excluded.

## Residuals

Five intrinsics are unsupported at the pin: `volatile_copy_memory`, `volatile_copy_nonoverlapping_memory`,
`volatile_set_memory`, `unaligned_volatile_load`, `unaligned_volatile_store`. Their harnesses remain under `#[cfg(not(kani))]`.
Fixes are merged in kani#4672 (first three) and kani#4673 (last two), but the repository still pins `d4df833`: **15/20 remains**.
A stand-in would omit volatile semantics and bypass codegen; kani#4672's investigation found `(dst, src)` reversed in the sketched `volatile_copy_memory` implementation.

Other open items:

- Copy mixed initialization and count-size overflow precondition independence.
- Wrapper-contract correspondence to backend codegen.
- Value-exchange oracles and implementation mutants for `mem::swap` / `typed_swap`;
  implementation mutants for volatile, vtable, `size_of_val`, and `compare_bytes` oracles.
- `size_of_val`: composite unsized tails and `extern type` metadata; volatile external memory/MMIO.
- Vtables: traits other than `Debug`, and final emitted vtables independently of compiler layout.
- Asserting-mode transmute failures at the object budget; larger budget untested.
- kani#90 remains open; its specific trigger is witnessed reachable here.
- macOS verification at this commit.

## Usage and exposing tables

The challenge's five usage sites and five exposing functions are separate from the `15/20` count.

| Row | Status here |
|---|---|
| `[T]::copy_from_slice` | Bounded real-caller proof exists elsewhere, not integrated; residual. |
| `core::mem::swap` | Two production-function contract harnesses; no value-exchange proof, row not counted. |
| `core::mem::align_of_val` | Bounded sized-`u32` real-caller probe; documented `T: ?Sized` domain remains residual. |
| `MaybeUninit::zeroed` | Bounded `u32` real-body probe exists elsewhere, not integrated; residual. |
| `parse_u64_into` | Absent; maintainer note below. |
| Five `std::ptr::*` exposing rows | Only `std::ptr::swap` resolves; all five residual pending intended targets. |

## Claim ledger

A machine-checkable manifest of the claims above — one entry per intrinsic with its harnesses, bounds,
assumptions, and an assurance band that says whether the claim's oracle was ever watched to fail — is at
https://github.com/ivmat/acceptance-format/tree/main/examples/verify-rust-std-pr618 (revision 2, for
`cf5fd23c`). Why it is there: this description states scope in prose; the manifest states the same
scope per claim in a fixed shape a reader can audit line by line and re-validate with the checker in
that repository, including the claims that have **no** control (all 15 per-intrinsic claims sit at the lowest band for
that reason; the one claim above it is the `copy_wrapper` byte-value oracle, which carries the observed-red
implementation mutation listed under *Controls*). It is hand-authored, is not part of this PR, and implies nothing about
acceptance.

## Notes for the maintainers

**`parse_u64_into`:** removed by `26d30a058104fe049a8b1d6d10d18ddf8c04864a` (nightly-2025-06-17 subtree update).
The current formatting path is not a one-to-one rename; the usage row needs an agreed disposition.

**`std::ptr` targets:** `copy_from_slice`, `parse_u64_into`, `align_of_val`, and `zeroed` do not resolve there.
Please clarify intended targets: `MaybeUninit::zeroed` and `mem::zeroed`, for example, have different safety boundaries.
No proof is transferred from another row.

The removed `write_bytes` kani#90 `FIXME` can be restored if preferred until upstream closure;
its guarded configuration verifies here with a cover witnessing the trigger.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
