### PR TITLE
Fix mod_inv precondition: any x is invertible modulo 1

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -2238,14 +2238,15 @@ pub(crate) unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usize {
     ///
     /// * `m` is a power-of-two;
     /// * `x < m`; (if `x ≥ m`, pass in `x % m` instead)
+    /// * `x` is odd, unless `m == 1` (any `x` is an inverse modulo 1)
     ///
     /// Implementation of this function shall not panic. Ever.
     #[safety::requires(m.is_power_of_two())]
     #[safety::requires(x < m)]
-    #[safety::requires(x % 2 != 0)]
+    #[safety::requires(m == 1 || x % 2 != 0)]
     // for Kani (v0.65.0), the below multiplication is too costly to prove
     #[cfg_attr(not(kani),
-        safety::ensures(|result| wrapping_mul(*result, x) % m == 1))]
+        safety::ensures(|result| wrapping_mul(*result, x) % m == 1 % m))]
     #[inline]
     const unsafe fn mod_inv(x: usize, m: usize) -> usize {
         /// Multiplicative modular inverse table modulo 2⁴ = 16.


### PR DESCRIPTION
The `x % 2 != 0` precondition on `ptr::mod_inv`, added in 6be9ca4b3f1e3557d34bbaa8e4c8bb0d7bc7b6c2 (#457), is violated by `mod_inv`'s only caller: `align_offset::<T>(p, 1)` with `size_of::<T>() > 1` takes the GENERAL_CASE path (since `1 % stride != 0`) and computes `s2 = (stride & 0) >> 0 = 0`, calling `mod_inv(0, 1)`. This is reachable e.g. via `<[u16]>::align_to::<u8>()`.

The violation is currently invisible in CI because `run-kani.sh` passes `--no-assert-contracts`; with dependency contracts asserted (the Kani default since model-checking/kani#3802), the harnesses `slice::verify::align_to_from_u16::align_to_u8`, `slice::verify::align_to_mut_from_char::align_to_mut_u8`, `slice::verify::align_to_mut_from_u32::align_to_mut_u8`, and `ptr::verify::check_align_offset_u16` all fail on the asserted `x % 2 != 0` clause.

The call is mathematically sound — modulo `m == 1` every value is trivially an inverse (the unique residue is 0), and `align_offset` masks the returned value with `a2 - 1 == 0` — so it is the precondition that is too strict, not the caller that is wrong: an inverse of `x` modulo a power of two `m` exists iff `gcd(x, m) == 1`, which for `m > 1` means odd `x` but for `m == 1` holds for all `x`. This PR weakens the precondition to `m == 1 || x % 2 != 0` and fixes the (kani-disabled) postcondition for the same degenerate case (`% m == 1 % m` instead of `% m == 1`, since modulo 1 the result is 0).

Verified with Kani 152c6a8c + CBMC 6.10.0: the four harnesses above now pass with contracts asserted, and the eight `ptr::verify::check_align_offset*` proof harnesses pass both with and without `--no-assert-contracts`.

Found while investigating what still blocks removing `--no-assert-contracts` from `run-kani.sh`: this is one of two genuine latent contract violations that asserting dependency contracts surfaces (the other: #623).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.