### PR TITLE
Respect new_unchecked precondition in IndexRange proof harnesses

### DIFF
--- a/library/core/src/ops/index_range.rs
+++ b/library/core/src/ops/index_range.rs
@@ -250,6 +250,10 @@ mod verify {
     fn proof_for_index_range_next_unchecked() {
         let start = kani::any::<usize>();
         let end = kani::any::<usize>();
+        // Respect new_unchecked's safety precondition (start <= end); the
+        // stronger requirement of next_unchecked (start < end) is assumed
+        // from its contract.
+        kani::assume(start <= end);
 
         let mut range = unsafe { IndexRange::new_unchecked(start, end) };
 
@@ -260,6 +264,10 @@ mod verify {
     fn proof_for_index_range_next_back_unchecked() {
         let start = kani::any::<usize>();
         let end = kani::any::<usize>();
+        // Respect new_unchecked's safety precondition (start <= end); the
+        // stronger requirement of next_back_unchecked (start < end) is
+        // assumed from its contract.
+        kani::assume(start <= end);
 
         let mut range = unsafe { IndexRange::new_unchecked(start, end) };
 


### PR DESCRIPTION
The `proof_for_contract` harnesses for `IndexRange::next_unchecked` and `IndexRange::next_back_unchecked`, introduced in a0fca1cc2f8b03f559d2fb9c09df97d5089e7ddf (#451), construct their `IndexRange` via `IndexRange::new_unchecked(start, end)` with entirely unconstrained `start` and `end`. That violates `new_unchecked`'s documented safety precondition (and `#[requires]` contract) `start <= end`: the assumption provided by the contract under verification only takes effect at the call to `next_unchecked` / `next_back_unchecked`, after the UB of the unchecked constructor call has already happened.

The violation is currently invisible in CI because `run-kani.sh` passes `--no-assert-contracts`; with dependency contracts asserted (the Kani default since model-checking/kani#3802), `proof_for_index_range_next_back_unchecked` fails on the asserted `start <= end` clause.

This PR constrains both harnesses with `kani::assume(start <= end)`. The stronger `start < end` required by the functions under verification continues to be assumed from their own contracts, preserving the intent of the harnesses.

Verified with Kani 152c6a8c + CBMC 6.10.0: all three `ops::index_range::verify` harnesses pass both with and without `--no-assert-contracts`.

Found while investigating what still blocks removing `--no-assert-contracts` from `run-kani.sh`: this is one of two genuine latent contract violations that asserting dependency contracts surfaces (the other: #622).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.