### PR TITLE
Replace byte-inspection NonZero contracts with niche test and raw_eq

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -419,21 +419,16 @@ where
     #[must_use]
     #[inline]
     #[track_caller]
-    #[requires({
-        let size = core::mem::size_of::<T>();
-        let ptr = &n as *const T as *const u8;
-        let slice = unsafe { core::slice::from_raw_parts(ptr, size) };
-        !slice.iter().all(|&byte| byte == 0)
-    })]
-    #[ensures(|result: &Self|{
-        let size = core::mem::size_of::<T>();
-        let n_ptr: *const T = &n;
-        let result_inner: T = result.get();
-        let result_ptr: *const T = &result_inner;
-        let n_slice = unsafe { core::slice::from_raw_parts(n_ptr as *const u8, size) };
-        let result_slice = unsafe { core::slice::from_raw_parts(result_ptr as *const u8, size) };
-        n_slice == result_slice
-    })]
+    // `NonZero::new` performs the canonical zero test via the niche layout
+    // (`Option<NonZero<T>>` has the same layout as `T`, with 0 as `None`),
+    // and `raw_eq` compares the object representations directly. Both are
+    // single operations for the verifier. Spelling these clauses as raw
+    // byte-slice inspections instead (as done previously) makes every
+    // asserted occurrence of this contract pay for symbolic pointer
+    // indirection and iterator reasoning, which dominated verification time
+    // of harnesses whose call graph contains NonZero constructions.
+    #[requires(NonZero::new(n).is_some())]
+    #[ensures(|result: &Self| unsafe { core::intrinsics::raw_eq(&result.get(), &n) })]
     pub const unsafe fn new_unchecked(n: T) -> Self {
         match Self::new(n) {
             Some(n) => n,
@@ -475,12 +470,9 @@ where
     #[must_use]
     #[inline]
     #[track_caller]
-    #[requires({
-        let size = core::mem::size_of::<T>();
-        let ptr = n as *const T as *const u8;
-        let slice = unsafe { core::slice::from_raw_parts(ptr, size) };
-        !slice.iter().all(|&byte| byte == 0)
-    })]
+    // See new_unchecked: the niche-layout zero test is much cheaper for the
+    // verifier than inspecting the object representation byte by byte.
+    #[requires(NonZero::new(*n).is_some())]
     pub unsafe fn from_mut_unchecked(n: &mut T) -> &mut Self {
         match Self::from_mut(n) {
             Some(n) => n,


### PR DESCRIPTION
The requires/ensures clauses of `NonZero::new_unchecked` (and the requires of `from_mut_unchecked`) expressed "n is not zero" and "result equals n" by building a raw byte slice over the value with `slice::from_raw_parts` and iterating it. Under symbolic execution, every asserted occurrence of these clauses pays for pointer indirection, slice-iterator reasoning, and allocation tracking — and since `new_unchecked` sits beneath most `NonZero` operations, harnesses whose call graph contains `NonZero` constructions were dominated by this: with dependency contracts asserted (the Kani default since model-checking/kani#3802), `num::nonzero::verify::check_mul_u32_small` takes 59.6s of CBMC solve time, against 0.3s with `--no-assert-contracts`.

This PR expresses the same properties through operations the verifier resolves directly: `NonZero::new(n).is_some()` performs the canonical zero test via the niche layout (a transmute plus discriminant test), and `intrinsics::raw_eq` compares object representations without constructing slices. Neither requires additional trait bounds on `T`.

Measured with Kani 152c6a8c + CBMC 6.10.0:
* `check_mul_u32_small` with contracts asserted: 59.6s → 0.6s solve time (103x).
* All 56 harnesses matching `nonzero_check_new_unchecked_for*` / `nonzero_check_from_mut_unchecked*` / `check_mul*` pass both with and without `--no-assert-contracts`.

Part of the effort to make dropping `--no-assert-contracts` from `run-kani.sh` feasible (see also #622, #623): the byte-inspection clauses were the single largest per-call-site cost multiplier identified when asserting dependency contracts across a 125-harness sample.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.