### PR TITLE
Update committee list in pull_requests.toml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @model-checking/kani-devs
+*   @model-checking/verify-rust-std-committee

--- a/.github/pull_requests.toml
+++ b/.github/pull_requests.toml
@@ -5,19 +5,17 @@ members = [
     "pnkfelix",
     "adpaco-aws",
     "feliperodri",
-    "zhassan-aws",
     "remi-delmas-3000",
-    "qinheping",
     "tautschnig",
     "patricklam",
     "ranjitjhala",
     "carolynzech",
-    "robdockins",
     "HuStmpHrrr",
-    "Eh2406",
     "jswrenn",
     "havelund",
     "jorajeev",
     "rajath-mk",
-    "thanhnguyen-aws"
+    "thanhnguyen-aws",
+    "btj",
+    "rafaelsamenezes"
 ]

--- a/.github/pull_requests.toml
+++ b/.github/pull_requests.toml
@@ -3,7 +3,6 @@ members = [
     "celinval",
     "rahulku",
     "pnkfelix",
-    "adpaco-aws",
     "feliperodri",
     "remi-delmas-3000",
     "tautschnig",
@@ -18,5 +17,6 @@ members = [
     "thanhnguyen-aws",
     "btj",
     "rafaelsamenezes",
-    "lucasccordeiro"
+    "lucasccordeiro",
+    "dkcumming"
 ]

--- a/.github/pull_requests.toml
+++ b/.github/pull_requests.toml
@@ -17,5 +17,6 @@ members = [
     "rajath-mk",
     "thanhnguyen-aws",
     "btj",
-    "rafaelsamenezes"
+    "rafaelsamenezes",
+    "lucasccordeiro"
 ]


### PR DESCRIPTION
Updates the verification committee in `.github/pull_requests.toml`.

**Removed:**
- adpaco-aws
- qinheping
- zhassan-aws
- robdockins
- Eh2406

**Added:**
- @btj
- @rafaelsamenezes
- @lucasccordeiro
- @dkcumming