### PR TITLE
Make subtree/library direct-push instruction prominent in update PR body

### DIFF
--- a/.github/workflows/update-subtree.yml
+++ b/.github/workflows/update-subtree.yml
@@ -146,14 +146,28 @@ jobs:
       uses: peter-evans/create-pull-request@v7
       with:
         title: 'Update subtree/library to ${{ env.NEXT_TOOLCHAIN_DATE }}'
-        body: >
-          This is an automated PR to update the subtree/library branch to the changes
+        body: |
+          This is an automated PR to update the `subtree/library` branch to the changes
           from ${{ env.CURRENT_TOOLCHAIN_DATE }} (rust-lang/rust@${{ env.CURRENT_COMMIT_HASH }})
           to ${{ env.NEXT_TOOLCHAIN_DATE }} (rust-lang/rust@${{ env.NEXT_COMMIT_HASH }}), inclusive.
 
-          **Review this PR as usual, but do not merge this PR using the GitHub web interface.
-          Instead, once it is approved, use `git push` to literally push the changes to `subtree/library`
-          without any rebase or merge.**
+          > [!IMPORTANT]
+          > **Do NOT use the GitHub "Merge pull request", "Squash and merge", or "Rebase and merge"
+          > buttons on this PR.** `subtree/library` must stay a verbatim, linear mirror of upstream's
+          > `library/` directory, regenerated deterministically by `splitsh-lite`. Any web-UI merge
+          > creates a synthetic commit that is not part of that extraction, which permanently diverges
+          > the branch and makes *every* future subtree-update PR conflict (and the daily job then keeps
+          > opening duplicate PRs).
+          >
+          > **To land this PR:** review it as usual, and once approved push its commits *literally* to
+          > `subtree/library` with no rebase and no merge:
+          >
+          > ```
+          > git fetch origin update-subtree/library
+          > git push origin origin/update-subtree/library:subtree/library
+          > ```
+          >
+          > This PR will close automatically once its commits are on `subtree/library`.
         branch: update-subtree/library
         delete-branch: true
         base: subtree/library


### PR DESCRIPTION
## Context

The `Update subtree/library to <date>` PRs opened by `.github/workflows/update-subtree.yml` must be landed by **pushing their commits directly** to `subtree/library` — never merged/squashed via the GitHub web UI. `subtree/library` is a verbatim, linear mirror of upstream's `library/` directory, regenerated deterministically by `splitsh-lite`. A web-UI merge injects a synthetic commit that is absent from that extraction, which permanently diverges the branch and makes *every* subsequent subtree-update PR conflict (and the daily job then re-opens duplicate PRs).

This exact failure just occurred: several such PRs were "Squash and merge"d, corrupting `subtree/library` and causing a cascade of conflicting/duplicate PRs. The mirror has since been repaired by force-pushing the clean extraction.

## Change

The existing note already said not to merge via the UI, but it was easy to miss (folded into the body text). This PR reformats it as a prominent `> [!IMPORTANT]` GitHub alert that:

- explicitly names the forbidden buttons (Merge / Squash and merge / Rebase and merge),
- explains *why* (deterministic mirror; synthetic commits diverge it and cascade conflicts),
- gives the exact `git push` commands to land the PR.

Only the automated PR-body text changes; no workflow logic is affected.