### PR TITLE
Add proof harnesses for unchecked_disjoint_bitor on unsigned integer …

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -2191,4 +2191,12 @@ mod verify {
         usize,
         checked_f128_to_int_unchecked_usize
     );
+
+    // `unchecked_disjoint_bitor` proofs
+    generate_unchecked_math_harness!(u8, unchecked_disjoint_bitor, checked_unchecked_disjoint_bitor_u8);
+    generate_unchecked_math_harness!(u16, unchecked_disjoint_bitor, checked_unchecked_disjoint_bitor_u16);
+    generate_unchecked_math_harness!(u32, unchecked_disjoint_bitor, checked_unchecked_disjoint_bitor_u32);
+    generate_unchecked_math_harness!(u64, unchecked_disjoint_bitor, checked_unchecked_disjoint_bitor_u64);
+    generate_unchecked_math_harness!(u128, unchecked_disjoint_bitor, checked_unchecked_disjoint_bitor_u128);
+    generate_unchecked_math_harness!(usize, unchecked_disjoint_bitor, checked_unchecked_disjoint_bitor_usize);
 }

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -2193,10 +2193,34 @@ mod verify {
     );
 
     // `unchecked_disjoint_bitor` proofs
-    generate_unchecked_math_harness!(u8, unchecked_disjoint_bitor, checked_unchecked_disjoint_bitor_u8);
-    generate_unchecked_math_harness!(u16, unchecked_disjoint_bitor, checked_unchecked_disjoint_bitor_u16);
-    generate_unchecked_math_harness!(u32, unchecked_disjoint_bitor, checked_unchecked_disjoint_bitor_u32);
-    generate_unchecked_math_harness!(u64, unchecked_disjoint_bitor, checked_unchecked_disjoint_bitor_u64);
-    generate_unchecked_math_harness!(u128, unchecked_disjoint_bitor, checked_unchecked_disjoint_bitor_u128);
-    generate_unchecked_math_harness!(usize, unchecked_disjoint_bitor, checked_unchecked_disjoint_bitor_usize);
+    generate_unchecked_math_harness!(
+        u8,
+        unchecked_disjoint_bitor,
+        checked_unchecked_disjoint_bitor_u8
+    );
+    generate_unchecked_math_harness!(
+        u16,
+        unchecked_disjoint_bitor,
+        checked_unchecked_disjoint_bitor_u16
+    );
+    generate_unchecked_math_harness!(
+        u32,
+        unchecked_disjoint_bitor,
+        checked_unchecked_disjoint_bitor_u32
+    );
+    generate_unchecked_math_harness!(
+        u64,
+        unchecked_disjoint_bitor,
+        checked_unchecked_disjoint_bitor_u64
+    );
+    generate_unchecked_math_harness!(
+        u128,
+        unchecked_disjoint_bitor,
+        checked_unchecked_disjoint_bitor_u128
+    );
+    generate_unchecked_math_harness!(
+        usize,
+        unchecked_disjoint_bitor,
+        checked_unchecked_disjoint_bitor_usize
+    );
 }


### PR DESCRIPTION
**Summary**
 - Add 6 proof_for_contract harnesses for unchecked_disjoint_bitor on u8, u16, u32, u64, u128, and usize
 - These functions had contracts (#[requires((self & other) == 0)]) but no verification harnesses
 
 **Verification**
 - All 6 harnesses pass locally with : ./scripts/run-kani.sh --kani-args --harness checked_unchecked_disjoint_bitor --output-format terse
 - Complete - 6 successfully verified harnesses, 0 failures, 6 total.