### PR TITLE
Add Kani proof harnesses and contracts for `unchecked_div_exact`

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1090,6 +1090,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[requires(rhs > 0 && self % rhs == 0 && (self != Self::MIN || rhs != -1))]
         pub const unsafe fn unchecked_div_exact(self, rhs: Self) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -2210,6 +2210,7 @@ mod verify {
         usize,
         checked_f128_to_int_unchecked_usize
     );
+
     // `unchecked_div_exact` proofs (small bit-widths: full range)
     generate_unchecked_math_harness!(i8, unchecked_div_exact, checked_unchecked_div_exact_i8);
     generate_unchecked_math_harness!(i16, unchecked_div_exact, checked_unchecked_div_exact_i16);
@@ -2222,58 +2223,105 @@ mod verify {
     generate_unchecked_div_exact_intervals!(
         i32,
         unchecked_div_exact,
-        checked_unchecked_div_exact_i32_small_divisor, 1, 64,
-        checked_unchecked_div_exact_i32_large_divisor, i32::MAX - 1000, i32::MAX,
-        checked_unchecked_div_exact_i32_edge_divisor, i32::MAX / 2, i32::MAX
+        checked_unchecked_div_exact_i32_small_divisor,
+        1,
+        64,
+        checked_unchecked_div_exact_i32_large_divisor,
+        i32::MAX - 1000,
+        i32::MAX,
+        checked_unchecked_div_exact_i32_edge_divisor,
+        i32::MAX / 2,
+        i32::MAX
     );
     generate_unchecked_div_exact_intervals!(
         i64,
         unchecked_div_exact,
-        checked_unchecked_div_exact_i64_small_divisor, 1, 64,
-        checked_unchecked_div_exact_i64_large_divisor, i64::MAX - 1000, i64::MAX,
-        checked_unchecked_div_exact_i64_edge_divisor, i64::MAX / 2, i64::MAX
+        checked_unchecked_div_exact_i64_small_divisor,
+        1,
+        64,
+        checked_unchecked_div_exact_i64_large_divisor,
+        i64::MAX - 1000,
+        i64::MAX,
+        checked_unchecked_div_exact_i64_edge_divisor,
+        i64::MAX / 2,
+        i64::MAX
     );
     generate_unchecked_div_exact_intervals!(
         i128,
         unchecked_div_exact,
-        checked_unchecked_div_exact_i128_small_divisor, 1, 64,
-        checked_unchecked_div_exact_i128_large_divisor, i128::MAX - 1000, i128::MAX,
-        checked_unchecked_div_exact_i128_edge_divisor, i128::MAX / 2, i128::MAX
+        checked_unchecked_div_exact_i128_small_divisor,
+        1,
+        64,
+        checked_unchecked_div_exact_i128_large_divisor,
+        i128::MAX - 1000,
+        i128::MAX,
+        checked_unchecked_div_exact_i128_edge_divisor,
+        i128::MAX / 2,
+        i128::MAX
     );
     generate_unchecked_div_exact_intervals!(
         isize,
         unchecked_div_exact,
-        checked_unchecked_div_exact_isize_small_divisor, 1, 64,
-        checked_unchecked_div_exact_isize_large_divisor, isize::MAX - 1000, isize::MAX,
-        checked_unchecked_div_exact_isize_edge_divisor, isize::MAX / 2, isize::MAX
+        checked_unchecked_div_exact_isize_small_divisor,
+        1,
+        64,
+        checked_unchecked_div_exact_isize_large_divisor,
+        isize::MAX - 1000,
+        isize::MAX,
+        checked_unchecked_div_exact_isize_edge_divisor,
+        isize::MAX / 2,
+        isize::MAX
     );
     generate_unchecked_div_exact_intervals!(
         u32,
         unchecked_div_exact,
-        checked_unchecked_div_exact_u32_small_divisor, 1, 64,
-        checked_unchecked_div_exact_u32_large_divisor, u32::MAX - 1000, u32::MAX,
-        checked_unchecked_div_exact_u32_edge_divisor, u32::MAX / 2, u32::MAX
+        checked_unchecked_div_exact_u32_small_divisor,
+        1,
+        64,
+        checked_unchecked_div_exact_u32_large_divisor,
+        u32::MAX - 1000,
+        u32::MAX,
+        checked_unchecked_div_exact_u32_edge_divisor,
+        u32::MAX / 2,
+        u32::MAX
     );
     generate_unchecked_div_exact_intervals!(
         u64,
         unchecked_div_exact,
-        checked_unchecked_div_exact_u64_small_divisor, 1, 64,
-        checked_unchecked_div_exact_u64_large_divisor, u64::MAX - 1000, u64::MAX,
-        checked_unchecked_div_exact_u64_edge_divisor, u64::MAX / 2, u64::MAX
+        checked_unchecked_div_exact_u64_small_divisor,
+        1,
+        64,
+        checked_unchecked_div_exact_u64_large_divisor,
+        u64::MAX - 1000,
+        u64::MAX,
+        checked_unchecked_div_exact_u64_edge_divisor,
+        u64::MAX / 2,
+        u64::MAX
     );
     generate_unchecked_div_exact_intervals!(
         u128,
         unchecked_div_exact,
-        checked_unchecked_div_exact_u128_small_divisor, 1, 64,
-        checked_unchecked_div_exact_u128_large_divisor, u128::MAX - 1000, u128::MAX,
-        checked_unchecked_div_exact_u128_edge_divisor, u128::MAX / 2, u128::MAX
+        checked_unchecked_div_exact_u128_small_divisor,
+        1,
+        64,
+        checked_unchecked_div_exact_u128_large_divisor,
+        u128::MAX - 1000,
+        u128::MAX,
+        checked_unchecked_div_exact_u128_edge_divisor,
+        u128::MAX / 2,
+        u128::MAX
     );
     generate_unchecked_div_exact_intervals!(
         usize,
         unchecked_div_exact,
-        checked_unchecked_div_exact_usize_small_divisor, 1, 64,
-        checked_unchecked_div_exact_usize_large_divisor, usize::MAX - 1000, usize::MAX,
-        checked_unchecked_div_exact_usize_edge_divisor, usize::MAX / 2, usize::MAX
+        checked_unchecked_div_exact_usize_small_divisor,
+        1,
+        64,
+        checked_unchecked_div_exact_usize_large_divisor,
+        usize::MAX - 1000,
+        usize::MAX,
+        checked_unchecked_div_exact_usize_edge_divisor,
+        usize::MAX / 2,
+        usize::MAX
     );
 }
-

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1719,6 +1719,25 @@ mod verify {
         }
     }
 
+    macro_rules! generate_unchecked_div_exact_intervals {
+        ($type:ty, $method:ident, $($harness_name:ident, $min:expr, $max:expr),+) => {
+            $(
+                #[kani::proof_for_contract($type::$method)]
+                pub fn $harness_name() {
+                    let num1: $type = kani::any::<$type>();
+                    let num2: $type = kani::any::<$type>();
+
+                    kani::assume(num1 >= $min && num1 <= $max);
+                    kani::assume(num2 >= $min && num2 <= $max);
+
+                    unsafe {
+                        num1.$method(num2);
+                    }
+                }
+            )+
+        }
+    }
+
     /// A macro to generate Kani proof harnesses for the `carrying_mul` method,
     ///
     /// The macro creates multiple harnesses for different ranges of input values,
@@ -2191,4 +2210,70 @@ mod verify {
         usize,
         checked_f128_to_int_unchecked_usize
     );
+    // `unchecked_div_exact` proofs (small bit-widths: full range)
+    generate_unchecked_math_harness!(i8, unchecked_div_exact, checked_unchecked_div_exact_i8);
+    generate_unchecked_math_harness!(i16, unchecked_div_exact, checked_unchecked_div_exact_i16);
+    generate_unchecked_math_harness!(u8, unchecked_div_exact, checked_unchecked_div_exact_u8);
+    generate_unchecked_math_harness!(u16, unchecked_div_exact, checked_unchecked_div_exact_u16);
+
+    // `unchecked_div_exact` interval-bounded proofs (for larger bit-widths)
+    // Note: rhs must be > 0 per the function's precondition, so all
+    // intervals below are restricted to positive divisor ranges only.
+    generate_unchecked_div_exact_intervals!(
+        i32,
+        unchecked_div_exact,
+        checked_unchecked_div_exact_i32_small_divisor, 1, 64,
+        checked_unchecked_div_exact_i32_large_divisor, i32::MAX - 1000, i32::MAX,
+        checked_unchecked_div_exact_i32_edge_divisor, i32::MAX / 2, i32::MAX
+    );
+    generate_unchecked_div_exact_intervals!(
+        i64,
+        unchecked_div_exact,
+        checked_unchecked_div_exact_i64_small_divisor, 1, 64,
+        checked_unchecked_div_exact_i64_large_divisor, i64::MAX - 1000, i64::MAX,
+        checked_unchecked_div_exact_i64_edge_divisor, i64::MAX / 2, i64::MAX
+    );
+    generate_unchecked_div_exact_intervals!(
+        i128,
+        unchecked_div_exact,
+        checked_unchecked_div_exact_i128_small_divisor, 1, 64,
+        checked_unchecked_div_exact_i128_large_divisor, i128::MAX - 1000, i128::MAX,
+        checked_unchecked_div_exact_i128_edge_divisor, i128::MAX / 2, i128::MAX
+    );
+    generate_unchecked_div_exact_intervals!(
+        isize,
+        unchecked_div_exact,
+        checked_unchecked_div_exact_isize_small_divisor, 1, 64,
+        checked_unchecked_div_exact_isize_large_divisor, isize::MAX - 1000, isize::MAX,
+        checked_unchecked_div_exact_isize_edge_divisor, isize::MAX / 2, isize::MAX
+    );
+    generate_unchecked_div_exact_intervals!(
+        u32,
+        unchecked_div_exact,
+        checked_unchecked_div_exact_u32_small_divisor, 1, 64,
+        checked_unchecked_div_exact_u32_large_divisor, u32::MAX - 1000, u32::MAX,
+        checked_unchecked_div_exact_u32_edge_divisor, u32::MAX / 2, u32::MAX
+    );
+    generate_unchecked_div_exact_intervals!(
+        u64,
+        unchecked_div_exact,
+        checked_unchecked_div_exact_u64_small_divisor, 1, 64,
+        checked_unchecked_div_exact_u64_large_divisor, u64::MAX - 1000, u64::MAX,
+        checked_unchecked_div_exact_u64_edge_divisor, u64::MAX / 2, u64::MAX
+    );
+    generate_unchecked_div_exact_intervals!(
+        u128,
+        unchecked_div_exact,
+        checked_unchecked_div_exact_u128_small_divisor, 1, 64,
+        checked_unchecked_div_exact_u128_large_divisor, u128::MAX - 1000, u128::MAX,
+        checked_unchecked_div_exact_u128_edge_divisor, u128::MAX / 2, u128::MAX
+    );
+    generate_unchecked_div_exact_intervals!(
+        usize,
+        unchecked_div_exact,
+        checked_unchecked_div_exact_usize_small_divisor, 1, 64,
+        checked_unchecked_div_exact_usize_large_divisor, usize::MAX - 1000, usize::MAX,
+        checked_unchecked_div_exact_usize_edge_divisor, usize::MAX / 2, usize::MAX
+    );
 }
+

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1308,6 +1308,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[requires(rhs > 0 && self % rhs == 0)]
         pub const unsafe fn unchecked_div_exact(self, rhs: Self) -> Self {
             assert_unsafe_precondition!(
                 check_language_ub,


### PR DESCRIPTION
## Summary

**⚠️ Coverage note: for `i32` and larger types, verification uses representative interval sampling, not exhaustive proof. Values outside the tested intervals are not covered. See "Verification strategy note" below for details.**

**This is a deliberate coverage trade-off: representative sampling, not an exhaustive proof, for large bit-widths. Values in the unconstrained middle range are not covered by these harnesses.**

This PR adds Kani function contracts and proof harnesses for `unchecked_div_exact`
on both signed and unsigned integer types (`i8`–`i128`, `isize`, `u8`–`u128`, `usize`).

`unchecked_div_exact` is an unstable intrinsic wrapper (tracking issue: rust-lang/rust#139911)
that computes `self / rhs` without checking for division-by-zero, non-exact division,
or overflow. It currently has no verification coverage in this repository.

## Changes

- Added `#[requires(...)]` contracts to `unchecked_div_exact` in:
  - `library/core/src/num/int_macros.rs` (signed integers)
  - `library/core/src/num/uint_macros.rs` (unsigned integers)
- Added proof harnesses in `library/core/src/num/mod.rs`:
  - Full-range harnesses for small bit-widths (`i8`, `i16`, `u8`, `u16`)
  - Interval-bounded harnesses (following the existing `generate_unchecked_mul_intervals`
    pattern) for larger bit-widths (`i32`, `i64`, `i128`, `isize`, `u32`, `u64`, `u128`, `usize`),
    each covering three representative divisor ranges: small values, values near `MAX`,
    and values near `MAX / 2`

## Precondition rationale

- Signed types: `rhs > 0 && self % rhs == 0 && (self != Self::MIN || rhs != -1)`
- Unsigned types: `rhs > 0 && self % rhs == 0`

These match the runtime `assert_unsafe_precondition!` checks already present in the
function body. The extra `MIN / -1` exclusion for signed types prevents the one
overflow case possible in exact division.

## Verification strategy note

For `i32` and larger types, exploratory unconstrained verification (`kani::any()` on both operands) was observed to take substantially longer than for smaller types, consistent with the exponential growth already visible at smaller bit-widths — the full-range `i16` and `u16` harnesses for this function verify in ~25s and ~55s respectively despite only a doubling in bit-width. Unconstrained runs on `i32` and larger types were abandoned in favor of interval bounding before a precise wall-clock time was recorded. Following the precedent set by `generate_unchecked_mul_intervals` for `unchecked_mul`, both operands are constrained to representative sub-ranges rather than the full domain. This is a deliberate coverage trade-off (representative sampling rather than exhaustive proof for large bit-widths), consistent with the existing pattern in this file. Values in the unconstrained middle range are not covered by these harnesses.

## Verification results

All 28 harnesses pass locally with 0 failures:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
