### PR TITLE
Forward Kani arguments to AutoHarness list commands

### DIFF
--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -315,7 +315,8 @@ main() {
     elif [[ "$run_command" == "list" ]]; then
         echo "Running Kani list command..."
         if [[ "$with_autoharness" == "true" ]]; then
-            "$kani_path" autoharness -Z autoharness --list $unstable_args --std ./library --format markdown
+            "$kani_path" autoharness -Z autoharness --list $unstable_args --std ./library --format markdown \
+                "${command_args[@]}"
         else
             "$kani_path" list $unstable_args ./library --std --format markdown
         fi
@@ -323,7 +324,8 @@ main() {
         local current_dir=$(pwd)
         echo "Running Kani list command..."
         if [[ "$with_autoharness" == "true" ]]; then
-            "$kani_path" autoharness -Z autoharness --list $unstable_args --std ./library --format json
+            "$kani_path" autoharness -Z autoharness --list $unstable_args --std ./library --format json \
+                "${command_args[@]}"
         else
             "$kani_path" list $unstable_args ./library --std --format json
         fi


### PR DESCRIPTION
## Summary

Forward arguments supplied through `--kani-args` to the AutoHarness list
invocations used by:

- `--run list --with-autoharness`
- `--run metrics --with-autoharness`

## Motivation

`run-kani.sh` parses and stores arguments following `--kani-args`, but the
AutoHarness list branches did not pass those arguments to Kani.

As a result, options such as `--include-pattern` and `--exclude-pattern` were
silently ignored, causing `list` and `metrics` to process the complete
AutoHarness function set instead of the requested subset.